### PR TITLE
CON-1062: Update references to the new conclave-core-sdk repo

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -21,8 +21,9 @@ jobs:
   automerge:
     runs-on: ubuntu-latest
     steps:
-      - name: basicautomerge
-        uses: "pascalgn/automerge-action@v0.12.0"
+      - id: basicautomerge
+        name: basicautomerge
+        uses: "pascalgn/automerge-action@v0.15.3"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           MERGE_LABELS: "!releasemerge,!wip"
@@ -30,8 +31,9 @@ jobs:
           UPDATE_METHOD: "merge"
           MERGE_DELETE_BRANCH: "true"
           MERGE_COMMIT_MESSAGE: "pull-request-title-and-description"
-      - name: releaseautomerge
-        uses: "pascalgn/automerge-action@v0.12.0"
+      - id: releaseautomerge
+        name: releaseautomerge
+        uses: "pascalgn/automerge-action@v0.15.3"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           MERGE_LABELS: "releasemerge,!wip"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,10 +37,11 @@ Before you submit your Pull Request (PR) consider the following guidelines:
 1. Search [GitHub][github] for an open or closed PR that relates to your submission. You don't want to 
 duplicate existing efforts.
 2. Be sure that an issue describes the problem you're fixing or documents the design for the feature you'd like to add.
+<!--- TODO: Update when the CLA process is finialised. --->
 3. Please sign our [Contributor License Agreement (CLA)](#cla) before sending PRs.
    We cannot accept code without a signed CLA. Make sure you author all contributed Git commits with email address associated with your CLA signature.
 4. Fork the project, set up the development environment, make your changes in a separate git branch and add descriptive messages to your commits.
-5. Push your branch to GitHub and send PR to `R3Conclave/conclave-sdk:master `.
+5. Push your branch to GitHub and send PR to `R3Conclave/conclave-core-sdk:master`.
 
 
 #### Addressing review feedback
@@ -61,5 +62,5 @@ If you have more than one GitHub account, or multiple email addresses associated
 
 [discord]: https://discord.gg/zpHKkMZ8Sw
 [mailing list]: https://groups.io/g/conclave-discuss
-[github]: https://github.com/R3Conclave/conclave-sdk
+[github]: https://github.com/R3Conclave/conclave-core-sdk
 [cla]: https://cla-assistant.io/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ Before you submit your Pull Request (PR) consider the following guidelines:
 1. Search [GitHub][github] for an open or closed PR that relates to your submission. You don't want to 
 duplicate existing efforts.
 2. Be sure that an issue describes the problem you're fixing or documents the design for the feature you'd like to add.
-<!--- TODO: Update when the CLA process is finialised. --->
+<!--- TODO: Update when the CLA process is finalized. --->
 3. Please sign our [Contributor License Agreement (CLA)](#cla) before sending PRs.
    We cannot accept code without a signed CLA. Make sure you author all contributed Git commits with email address associated with your CLA signature.
 4. Fork the project, set up the development environment, make your changes in a separate git branch and add descriptive messages to your commits.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Conclave Core SDK](.github/assets/logo.png)][conclave_website]
 
-The [Conclave Core SDK][docs] is an open source platform that lets you create SGX enclaves very easily. You can 
-write your enclave code in high-level languages such as Java, Kotlin and JavaScript.
+The [Conclave Core SDK][docs] is an open source platform that lets you create SGX enclaves easily. You can 
+write your enclave code in high-level languages such as Java, Kotlin, and JavaScript.
 
 **Enclaves** are small pieces of software that are protected from attack by the owner of the computer on which they 
 run. They are ideally suited to solving multi-party collaboration and privacy problems, 
@@ -15,7 +15,7 @@ If you want to learn how to use Conclave and build enclaves, take a look at the
 [API docs](https://docs.conclave.net/api/index.html).
 
 ## Contributing
-We encourage you to contribute to Conclave. Have a read of our contribution [guidelines](CONTRIBUTING.md).
+We encourage you to contribute to Conclave. Please read our contribution [guidelines](CONTRIBUTING.md).
 
 ### Community
 You can also interact with the Conclave community on these channels:

--- a/README.md
+++ b/README.md
@@ -1,46 +1,33 @@
-[![Conclave SDK](.github/assets/logo.png)][conclave_website]
+[![Conclave Core SDK](.github/assets/logo.png)][conclave_website]
 
-## Overview
-[Conclave SDK][docs] is an open source platform that makes working with SGX enclaves easy.
+The [Conclave Core SDK][docs] is an open source platform that lets you create SGX enclaves very easily. You can 
+write your enclave code in high-level languages such as Java, Kotlin and JavaScript.
 
-It is a toolkit for building **enclaves**, small pieces of software that are protected from attack 
-by the owner of the computer on which they run. 
-It is ideally suited to solving multi-party collaboration and privacy problems, 
+**Enclaves** are small pieces of software that are protected from attack by the owner of the computer on which they 
+run. They are ideally suited to solving multi-party collaboration and privacy problems, 
 but can also be used to secure your infrastructure against attack.
 
-Conclave SDK has been originally developed by [R3][r3_website], and it is has been made available 
-to the community, see the [license below](#license).
+The Conclave Core SDK is developed by [R3][r3_website], and has been made available to the [open source community](#license).
 
-### Documentation and tutorials
-Please refer to the [Conclave website for documentation and tutorials][docs].
-Sources of the documentation are under the directory [docs/](docs/docs).
+## How to use Conclave
+If you want to learn how to use Conclave and build enclaves, take a look at the
+[hello world example and tutorial][hello_world]. You can also refer to the [Conclave documentation][docs] and
+[API docs](https://docs.conclave.net/api/index.html).
 
-### Contributing
-We encourage you to contribute to Conclave. As a contributor please [follow these guidelines](#contributing.md).
+## Contributing
+We encourage you to contribute to Conclave. Have a read of our contribution [guidelines](CONTRIBUTING.md).
 
 ### Community
-You can interact with the Conclave SDK community on these channels:
+You can also interact with the Conclave community on these channels:
 
-[Discord channel](https://discord.gg/zpHKkMZ8Sw)
+[Discord](https://discord.gg/zpHKkMZ8Sw)
 
 [Mailing list](https://groups.io/g/conclave-discuss)
 
-## Usage
-If you want to start using Conclave SDK and building enclaves, please see
-the [Hello World example and tutorials][hello_world].
-
-<!--- TODO: <https://r3-cev.atlassian.net/browse/CON-1020> (This is the Jira ticket to publish artifacts to Maven Central.) --->
-Pre-built artifacts of Conclave SDK are present in [Maven Central](https://MAVEN_CENTRAL_REPOSITORY_TO_BE_ADDED),
-so you just need to use that repository and add the related dependencies to your project.
-
-Conclave SDK currently only fully supports Ubuntu Linux. There is a limited support for macOS and Windows:
-you **can build** the enclaves, but you **can't run** enclaves on them.
-
 ## Building the SDK
-If you want to modify the source code of Conclave SDK, you can develop on macOS (Intel) and Linux platforms by using 
-a development Docker container that we have prepared.
-If you are comfortable on Linux, you might want to use Dell laptops: they support SGX, and it is 
-convenient to use SGX locally.
+If you want to build the SDK, you can do so both on Linux and macOS (Intel only) using a development Docker container.
+
+> :warning: **Building the SDK is currently not supported on Apple Silicon hardware.
 
 In the instructions below we assume Ubuntu as the Linux distribution; in case you use a different one,
 you need to translate the instructions to your chosen distribution.
@@ -48,15 +35,14 @@ you need to translate the instructions to your chosen distribution.
 ### Getting the source code
 To retrieve the source code you need to clone this repository:
 ```shell
-git clone https://github.com/R3Conclave/conclave-sdk.git
+git clone https://github.com/R3Conclave/conclave-core-sdk.git
 ```
 
-### Preparing your development container
+### Preparing the development container
 We have created Docker containers to have an encapsulated and easy-to-use build environment, follow the instructions
 for your operating system.
 
 #### macOS (Intel)
-> :warning: **Conclave SDK is currently not supported on Apple Silicon CPUs.
 
 You can install Docker Desktop [following Docker's instructions](https://docs.docker.com/desktop/mac/install/)
 
@@ -95,7 +81,7 @@ You are now in a shell inside a Docker container.
 Run ./gradlew build test to compile and run unit tests.
 Browse to http://localhost:8000 to view the external docsite.
 
-conclave master ~/conclave-sdk> 
+conclave master ~/conclave-core-sdk> 
 ```
 
 ### Building the SDK and runnning tests
@@ -128,7 +114,7 @@ cd integration-tests
 > In this way you will be using the container as a `root` user.
 > 
 ### Debug mode
-As part of the build, Conclave SDK uses a modified version of [Intel SGX SDK](https://github.com/intel/linux-sgx),
+As part of the build, Conclave uses a modified version of the [Intel SGX SDK](https://github.com/intel/linux-sgx),
 together with other C/C++ code.
 By default, this code is built in `Release` mode. If you need to debug C/C++ code you need to set the `Debug` mode by adding
 `-PnativeDebug` to the parameters. e.g. 
@@ -162,7 +148,7 @@ By default, the IDEs will be downloaded under the host's `~/.opt/` folder.
 You can now use these commands to launch your IDE of choice:
 
 ```shell
-cd <conclave-sdk's local repository>
+cd <conclave-core-sdk's local repository>
 ./scripts/idea.sh      # starts IDEA in a container
 ./scripts/clion.sh     # starts CLion in a container
 ```
@@ -180,40 +166,39 @@ docker stop $(docker ps -f label=sdk-build -q)
 
 If you stop the container, you can restart it and log back in by re-running the `devenv_shell.sh` script.
 
-**Gradle** maintains various caches and such in the container in the `/gradle` directory (this won't appear on your host
+Gradle maintains various caches and such in the container in the `/gradle` directory (this won't appear on your host
 system). If your container gets messed up you can blow it away by stopping it and then using `docker images` to list the
 image, and `docker rmi` to delete the image. Then rerun `devenv_shell.sh` to re-download things fresh.
 
 
 ## Exploring the codebase
 
-Conclave SDK consists of several technologies bundled together. Here is a description of the most
+The Conclave Core SDK consists of several technologies working together. Here is a description of the most
 meaningful directories in this repo.
 
-| Directory                                                                                                                                                                                                                                                                                                    | Description                                                                                                                                                                                                                                                                                                    |
-|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [azure&#x2011;plugin/](azure-plugin)                                                                                                                                                                                                                                                                         | This contains script and tools to use the SDK in an Azure Virtual Machine.                                                                                                                                                                                                                                     |
-| [conclave&#x2011;client/](conclave-client)<br/>[conclave&#x2011;common/](conclave-common)<br/>[conclave&#x2011;host/](conclave-host)<br/>[conclave&#x2011;mail/](conclave-mail)<br/>[conclave&#x2011;web&#x2011;client/](conclave-web-client)<br/>[conclave&#x2011;web&#x2011;host/](conclave-web-host)<br/> | These directories contain the public modules of the Conclave API.                                                                                                                                                                                                                                              |
-| [conclave&#x2011;init/](conclave-init)                                                                                                                                                                                                                                                                       | This is a tool to quickly and automatically generate a Conclave project.                                                                                                                                                                                                                                       |
-| [containers/conclave&#x2011;build/](containers/conclave-build)                                                                                                                                                                                                                                               | This contains the definition of a Linux container used to build an enclave in Windows and macOS.                                                                                                                                                                                                               |
-| [containers/sdk&#x2011;build/](containers/sdk-build)                                                                                                                                                                                                                                                         | This contains the definition and the scripts to create and use a container to build Conclave SDK.                                                                                                                                                                                                              |
-| [cpp/](cpp)                                                                                                                                                                                                                                                                                                  | This is where all C++ code resides. This is mostly a CMake project, with a wrapper `build.gradle` extracting the artifacts.                                                                                                                                                                                    |
-| [cpp/fatfs/](cpp/fatfs)                                                                                                                                                                                                                                                                                      | This code creates the representation of the enclave filesystem using FatFs.                                                                                                                                                                                                                                    |
-| [cpp/jvm&#x2011;edl/](cpp/jvm-edl)                                                                                                                                                                                                                                                                           | This is where we generate the ECALL/OCALL boundary using Intel's EDL language. Note that the boundary is minimal, the  JVM boundary is implemented on top of this.                                                                                                                                             |
-| [cpp/jvm&#x2011;enclave&#x2011;common/](cpp/jvm-enclave-common)                                                                                                                                                                                                                                              | This is C/C++ enclave code that implements or stubs Linux system POSIX calls.                                                                                                                                                                                                                                  |
-| [cpp/jvm&#x2011;host/](cpp/jvm-host)                                                                                                                                                                                                                                                                         | This is C/C++ host code to interact with Java/Kotlin host code through JNI.                                                                                                                                                                                                                                    |
-| [cpp/jvm&#x2011;host&#x2011;enclave&#x2011;common/](cpp/jvm-host-enclave-common)                                                                                                                                                                                                                             | This is C/C++ code used both by the host and the enclave. It mainly consists of utility functions/classes.                                                                                                                                                                                                     |
-| [cpp/jvm&#x2011;host&#x2011;shared/](cpp/jvm-host-shared)                                                                                                                                                                                                                                                    | This is C/C++ host code, mainly to retrieve hardware information using Intel SGX SDK.                                                                                                                                                                                                                          |
-| [cpp/linux&#x2011;sgx/](cpp/linux-sgx)                                                                                                                                                                                                                                                                       | This directory contains modifications to the Intel SGX SDK. CMake checks out the [Intel SGX SDK](https://github.com/intel/linux-sgx) and applies some patches on top of it. The build compiles the SDK, installs it locally on a build directory so the PSW compilation (`cpp/psw`) can find its dependencies. |
-| [cpp/substratevm/](cpp/substratevm)                                                                                                                                                                                                                                                                          | This is C/C++ enclave code, with the implementation of the entry points (host to enclave) of some EDL code.                                                                                                                                                                                                    |
-| [docs/](docs)                                                                                                                                                                                                                                                                                                | This contains the source code for the [Conclave documentation](https://docs.conclave.net).                                                                                                                                                                                                                     |
-| [dokka/](dokka)                                                                                                                                                                                                                                                                                              | This contains a script to build a fork of [Dokka](https://github.com/Kotlin/dokka), a documentation engine for Kotlin.                                                                                                                                                                                         |
-| [integration&#x2011;tests/](integration-tests)                                                                                                                                                                                                                                                               | This is a separate independent Gradle project which is used to test the SDK artifacts at an integration-level.                                                                                                                                                                                                 |
-| [plugin&#x2011;enclave&#x2011;gradle/](plugin-enclave-gradle)                                                                                                                                                                                                                                                | This is a Gradle plugin which automates all the process for taking a partial enclave file and producing a signed one which contains the end-user enclave code, and which can be used seamlessly by the host code.                                                                                              |
-| [scripts/](scripts)                                                                                                                                                                                                                                                                                          | This contains shell scripts and utilities used for managing deployment, developer environments, releases etc.                                                                                                                                                                                                  |
+| Directory                                                                                                                                                                                                                                          | Description                                                                                                                 |
+|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------|
+| [conclave&#x2011;client/](conclave-client)<br/>[conclave&#x2011;common/](conclave-common)<br/>[conclave&#x2011;host/](conclave-host)<br/>[conclave&#x2011;mail/](conclave-mail)<br/>[conclave&#x2011;web&#x2011;client/](conclave-web-client)<br/> | Kotlin/Java code of the Core API.                                                                                           |
+| [conclave&#x2011;web&#x2011;host/](conclave-web-host)                                                                                                                                                                                              | Simple web-based Conclave [host server](https://docs.conclave.net/conclave-web-host.html).                                  |
+| [conclave&#x2011;init/](conclave-init)                                                                                                                                                                                                             | This is a tool to quickly and automatically generate a Conclave project.                                                    |
+| [containers/conclave&#x2011;build/](containers/conclave-build)                                                                                                                                                                                     | Docker container for building Conclave enclaves in Windows and macOS.                                                       |
+| [containers/sdk&#x2011;build/](containers/sdk-build)                                                                                                                                                                                               | Docker container for building the Conclave Core SDK.                                                                        |
+| [cpp/](cpp)                                                                                                                                                                                                                                        | This is where all C++ code resides. This is mostly a CMake project, with a wrapper `build.gradle` extracting the artifacts. |
+| [cpp/fatfs/](cpp/fatfs)                                                                                                                                                                                                                            | This code creates the representation of the enclave filesystem using FatFs.                                                 |
+| [cpp/jvm&#x2011;edl/](cpp/jvm-edl)                                                                                                                                                                                                                 | The minimal ECALL/OCALL boundary using Intel's EDL language.                                                                |
+| [cpp/jvm&#x2011;enclave&#x2011;common/](cpp/jvm-enclave-common)                                                                                                                                                                                    | Implementations and stubs of Linux system POSIX calls inside the enclave.                                                   |
+| [cpp/jvm&#x2011;host/](cpp/jvm-host)                                                                                                                                                                                                               | Native code which interacts with the Java/Kotlin layer through JNI.                                                         |
+| [cpp/jvm&#x2011;host&#x2011;enclave&#x2011;common/](cpp/jvm-host-enclave-common)                                                                                                                                                                   | Native code used both by the host and the enclave. It mainly consists of utility functions/classes.                         |
+| [cpp/linux&#x2011;sgx/](cpp/linux-sgx)                                                                                                                                                                                                             | Conclave modifications to the [Intel SGX SDK](https://github.com/intel/linux-sgx).                                          |
+| [cpp/substratevm/](cpp/substratevm)                                                                                                                                                                                                                | This is C/C++ enclave code, with the implementation of the entry points (host to enclave) of some EDL code.                 |
+| [docs/](docs)                                                                                                                                                                                                                                      | This contains the source code for the [Conclave documentation](https://docs.conclave.net).                                  |
+| [dokka/](dokka)                                                                                                                                                                                                                                    | This contains a script to build a fork of [Dokka](https://github.com/Kotlin/dokka), a documentation engine for Kotlin.      |
+| [integration&#x2011;tests/](integration-tests)                                                                                                                                                                                                     | This is a separate independent Gradle project which is used to test the SDK artifacts at an integration-level.              |
+| [plugin&#x2011;enclave&#x2011;gradle/](plugin-enclave-gradle)                                                                                                                                                                                      | The Conclave Grade enclave plugin which automates the process of building a native SGX binary.                              |
+| [scripts/](scripts)                                                                                                                                                                                                                                | Various scripts for building and testing the SDK.                                                                           |
 
 ## License
-Conclave SDK is open source and distributed under the [Apache License v2.0](LICENSE).
+The Conclave Core SDK is open source and distributed under the [Apache License v2.0](LICENSE).
 
 It incorporates components from third-party open source libraries. See the [NOTICE](NOTICE.md) file for more information.
 

--- a/build.gradle
+++ b/build.gradle
@@ -178,10 +178,10 @@ List<PublishedProject> publishedProjects = [
 
 import org.jetbrains.dokka.gradle.DokkaTask
 tasks.withType(DokkaTask).configureEach {
-    moduleName.set("Conclave")
+    moduleName.set("Conclave Core")
     dokkaSourceSets {
         register("conclave") {
-            displayName.set("Conclave")
+            displayName.set("Conclave Core")
             jdkVersion.set(8)
             reportUndocumented.set(false)
             skipDeprecated.set(true)

--- a/conclave-client/src/main/kotlin/com/r3/conclave/client/EnclaveTransport.kt
+++ b/conclave-client/src/main/kotlin/com/r3/conclave/client/EnclaveTransport.kt
@@ -13,7 +13,7 @@ import java.io.IOException
  *
  * Details such as how to start and shutdown the transport are implementation specific.
  *
- * [com.r3.conclave.client.web.WebEnclaveTransport] is a HTTP RESTful implementation for connecting the client to a
+ * [com.r3.conclave.client.web.WebEnclaveTransport] is an HTTP RESTful implementation for connecting the client to a
  * host which is using the `conclave-web-host` module.
  *
  * @see EnclaveClient

--- a/conclave-client/src/main/kotlin/com/r3/conclave/client/EnclaveTransport.kt
+++ b/conclave-client/src/main/kotlin/com/r3/conclave/client/EnclaveTransport.kt
@@ -13,8 +13,8 @@ import java.io.IOException
  *
  * Details such as how to start and shutdown the transport are implementation specific.
  *
- * The Conclave SDK provides [com.r3.conclave.client.web.WebEnclaveTransport] as an implementation for connecting the
- * client to a host which is using the `conclave-web-host`.
+ * [com.r3.conclave.client.web.WebEnclaveTransport] is a HTTP RESTful implementation for connecting the client to a
+ * host which is using the `conclave-web-host` module.
  *
  * @see EnclaveClient
  * @see com.r3.conclave.client.web.WebEnclaveTransport

--- a/conclave-web-host/README.md
+++ b/conclave-web-host/README.md
@@ -1,2 +1,2 @@
 # conclave-web-host
-This module is the web-host section of the Conclave API.
+This is the web-based Conclave host

--- a/conclave-web-host/README.md
+++ b/conclave-web-host/README.md
@@ -1,2 +1,2 @@
 # conclave-web-host
-This is the web-based Conclave host
+This is the web-based Conclave host.

--- a/containers/README.md
+++ b/containers/README.md
@@ -1,2 +1,2 @@
 # containers
-This is a set of scripts used to set up Docker containers to build and use Conclave SDK.
+This is a set of scripts used to set up Docker containers to build and use the SDK.

--- a/containers/sdk-build/src/docker/Dockerfile
+++ b/containers/sdk-build/src/docker/Dockerfile
@@ -7,9 +7,7 @@ RUN mkdir $GRAAL_HOME && tar -C $GRAAL_HOME -xzf $docker_graal_tar_file && rm -r
 
 FROM graal
 
-# TODO Separate out the enclave build and make it completely reproducible.
-
-LABEL description="Build container for the Conclave SDK"
+LABEL description="Build container for the Conclave Core SDK"
 LABEL maintainer="conclave@r3.com"
 ARG commit_id
 LABEL commit_id=${commit_id}

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.2)
 
-project(conclave-sdk-cpp VERSION 0.1 LANGUAGES CXX)
+project(conclave-core-sdk-cpp VERSION 0.1 LANGUAGES CXX)
 include(CTest)
 
 set(CMAKE_VERBOSE_MAKEFILE ON)

--- a/cpp/linux-sgx/README.md
+++ b/cpp/linux-sgx/README.md
@@ -1,5 +1,5 @@
 # cpp/linux-sgx
 This contains patches to the [Intel SGX SDK](https://github.com/intel/linux-sgx) to make it work with Conclave.
 
-The build compiles the SDK, installs it locally on a build directory so the PSW compilation (`cpp/psw`) can find its
+The build compiles the SDK and installs it locally on a build directory so the PSW compilation (`cpp/psw`) can find its
 dependencies.

--- a/cpp/linux-sgx/README.md
+++ b/cpp/linux-sgx/README.md
@@ -1,2 +1,5 @@
 # cpp/linux-sgx
-This contains the [Intel SGX SDK](https://github.com/intel/linux-sgx) with additional patches to make it work in Conclave.
+This contains patches to the [Intel SGX SDK](https://github.com/intel/linux-sgx) to make it work with Conclave.
+
+The build compiles the SDK, installs it locally on a build directory so the PSW compilation (`cpp/psw`) can find its
+dependencies.

--- a/docs/docs/api-changes.md
+++ b/docs/docs/api-changes.md
@@ -43,7 +43,7 @@ they are _not_ thread-safe.
 
 Conclave Init now requires Java 17 to run, and generated projects will target Java 17 by default.
 
-The SDK version is now set at the individual project level, rather at the OS user
+The SDK version is now set at the individual project level rather than at the OS user
 level. This means the `--configure-gradle` option is no longer needed and has been removed.
 
 ## 1.1 to 1.2

--- a/docs/docs/api-changes.md
+++ b/docs/docs/api-changes.md
@@ -43,7 +43,7 @@ they are _not_ thread-safe.
 
 Conclave Init now requires Java 17 to run, and generated projects will target Java 17 by default.
 
-Conclave SDK version is now set at the individual project level, rather at the OS user
+The SDK version is now set at the individual project level, rather at the OS user
 level. This means the `--configure-gradle` option is no longer needed and has been removed.
 
 ## 1.1 to 1.2

--- a/docs/docs/conclave-web-host.md
+++ b/docs/docs/conclave-web-host.md
@@ -40,7 +40,7 @@ Timeout to use when attempting to contact the key derivation service enclave.
 
 ## REST API:
 The REST API consists of several endpoints, detailed below. When using this API, clients begin an interaction with 
-the enclave by fetching an attestation. The client will then use the Conclave SDK to examine the attestation 
+the enclave by fetching an attestation. The client will then use Conclave to examine the attestation 
 information and make a decision whether to proceed (see [enclave-constraints](constraints.md)). If the enclave is 
 deemed to be trusted by the client, then an encryption key is derived from the attestation data, and the client can 
 continue to interact with the enclave via the host by delivering and receiving encrypted messages using the the 

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -188,7 +188,7 @@ You *don't* need to trust:
 other hardware components are all untrusted in the SGX threat model.
 * The owner of the hardware on which your enclave is running. You can verify the remote attestation to ensure that the
 remote system is up to date and that the enclave is running securely.
-* R3, as Conclave is [open source](https://github.com/R3Conclave/conclave-sdk).
+* R3, as Conclave is [open source](https://github.com/R3Conclave/conclave-core-sdk).
 
 ### How should I authenticate users of my enclave?
 

--- a/docs/docs/ide-configuration.md
+++ b/docs/docs/ide-configuration.md
@@ -4,7 +4,7 @@
     even if you provide this configuration. Instead, please refer to the [online Javadocs](https://docs.conclave.net/api/index.html)
     for Conclave.
 
-Some IDEs are able to automatically display Conclave SDK documentation whilst editing code. In order for this to
+Some IDEs are able to automatically display Conclave documentation whilst editing code. In order for this to
 work you may need to add some configuration to the root `build.gradle` depending on your IDE.
 
 Start by adding the Gradle plugin required to support your IDE. Note that Visual Studio Code shares the configuration

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -28,7 +28,8 @@ Conclave makes [Confidential Computing](enclaves.md) using Intel® Security Guar
 - **Developer-friendly:** You don't have to be a cryptography expert to use Conclave. A high-level, intuitive API helps you write secure applications on any operating system.
 - **Code in many languages:** Write your code in Java, Kotlin, or any other JVM (Java Virtual Machine) language. You can also use Javascript and basic Python to write your application.
 - **Focus on business logic:** Interact with secure enclaves easily using an intuitive API. **Conclave Mail** takes care of the end-to-end encrypted messaging.
-- **Everything in one platform:** Conclave SDK tightly integrates with a [complementary cloud offering](https://www.conclave.net/conclave-cloud/).
+- **Everything in one platform:** The Core SDK tightly integrates with a
+  [complementary cloud offering](https://www.conclave.net/conclave-cloud/).
 - **Cloud-based Key Derivation Service (KDS):** Create stable applications that maintain Intel SGX security guarantees even when the enclave runs on multiple physical machines.
 - **Enhanced security, performance, and capabilities:** Conclave uses the GraalVM native image technology for incredibly tight memory usage, support for GraalVM languages, and instant startup time.
 - **Quickly deploy to Microsoft Azure:** Run Conclave apps on Microsoft Azure VMs with minimal setup.

--- a/docs/docs/kds-detail.md
+++ b/docs/docs/kds-detail.md
@@ -162,7 +162,7 @@ parameters to the function.
 ![](images/kds_key_derivation.png)
 
 In the diagram above, an enclave built using Conclave wants to use a key from
-the KDS for persistence so the Conclave SDK makes a request to the KDS based on
+the KDS for persistence so a request is made to the KDS based on
 the configuration provided inside the enclave code. The request to the KDS
 includes the key specification, consisting of the "Master Key" to use and the
 key policy constraint that must be met in order for the KDS to release a key to
@@ -227,13 +227,12 @@ the application enclave.
 
 ![](images/kds_key_exchange.png)
 
-All of this happens behind the scenes to developers using the Conclave SDK: the
-Conclave SDK automatically performs all required mechanisms required to ensure a
-secure key exchange.
+All of this happens behind the scenes to developers using the Conclave Core SDK: it automatically performs all 
+required mechanisms required to ensure a secure key exchange.
 
 # What is the 'Master Key'?
-In order for the KDS to provide stable keys to enclaves developed with the
-Conclave SDK, the KDS itself needs access to a stable master key. Rather than
+In order for the KDS to provide stable keys to enclaves developed with Conclave, the KDS itself needs access to a 
+stable master key. Rather than
 providing one fixed master key, the KDS can be given access to different sources
 of master key, the actual master key to use being provided as part of the key
 specification.

--- a/docs/docs/release-notes.md
+++ b/docs/docs/release-notes.md
@@ -4,7 +4,7 @@ Release notes
 ### 1.3
 
 1. :tada: **The Conclave Core SDK is now open source!** :tada: Read our blog post on why we made it open source and 
-   what this means for you. You can find the source code at https://github.com/R3Conclave/conclave-sdk.
+   what this means for you. You can find the source code at https://github.com/R3Conclave/conclave-core-sdk.
 2. The SDK artifacts are now available on Maven Central. There's no longer any need to have a local repo 
    directory in your Conclave project. See the [API changes page](api-changes.md#maven-central) for more details.  
 3. The Core SDK powers our new Conclave Cloud platform. Head over to https://conclave.cloud to learn more. 

--- a/docs/docs/running-hello-world.md
+++ b/docs/docs/running-hello-world.md
@@ -27,8 +27,8 @@ cd conclave-tutorials/hello-world
 ```
 
 The sample app, like all Conclave apps, consists of an
-[enclave and a client](architecture.md#primary-entities). The enclave runs inside a host app,
-which is provided by the Conclave SDK. We can generate a fat JAR for the host and client using the `:bootJar` and
+[enclave and a client](architecture.md#primary-entities). The enclave runs inside a host application,
+which is provided by the Conclave Core SDK. We can generate a fat JAR for the host and client using the `:bootJar` and
 `:shadowJar` tasks, respectively.
 === "Windows"
     ```bash

--- a/dokka/README.md
+++ b/dokka/README.md
@@ -36,7 +36,7 @@ Each fix is a separate commit in the 'conclave-changes' branch of https://github
 
 
 ## Using the R3 dokka version
-The Conclave SDK root gradle project refers to the dokka plugin, therefore the plugin itself cannot be built as part
+The root Gradle project refers to the dokka plugin, therefore the plugin itself cannot be built as part
 of the build script. Instead, dokka must be built and published and be made available in a maven repository before Conclave can be built. 
 To achieve this, we publish a pre-built zip file containing the required repository to our github fork of dokka. This is 
 then downloaded and unzipped in our sdk-build container. The repo is put into /opt/dokka. The conclave build.gradle 

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -1,6 +1,6 @@
 # Integration Tests
 
-This is a separate Gradle project which uses a locally published repository containing the Conclave SDK libraries to 
+This is a separate Gradle project which uses a locally published repository containing the Core SDK libraries to 
 run integration-level tests. This repository is expected at the location `../build/repo`, which can be produced by 
 running
 

--- a/integration-tests/kotlin-enclave/host/src/test/kotlin/com/r3/conclave/integrationtests/kotlin/enclave/ApiKotlinConsumerTest.kt
+++ b/integration-tests/kotlin-enclave/host/src/test/kotlin/com/r3/conclave/integrationtests/kotlin/enclave/ApiKotlinConsumerTest.kt
@@ -11,8 +11,8 @@ import org.junit.jupiter.api.Test
 import java.security.PrivateKey
 
 /**
- * This test makes sure that the shading of Kotlin into the Conclave SDK does not prevent an app from being written in
- * Kotlin.
+ * This test makes sure that the shading of Kotlin into the Conclave libraries does not prevent an app from being
+ * written in Kotlin.
  */
 class ApiKotlinConsumerTest {
     private lateinit var host: EnclaveHost

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
     }
 }
 
-rootProject.name = "conclave-sdk"
+rootProject.name = "conclave-core-sdk"
 
 include 'cpp'
 include 'conclave-mail'


### PR DESCRIPTION
Also changed "Conclave SDK" references to either be more specific by adding "Core" or modified in other ways.

The root README has also been cleaned up.