### PR TITLE
Updated conclave-init generated project to not use deprecated Gradle API

### DIFF
--- a/conclave-init/src/test/kotlin/com/r3/conclave/init/CreateProjectTest.kt
+++ b/conclave-init/src/test/kotlin/com/r3/conclave/init/CreateProjectTest.kt
@@ -96,11 +96,11 @@ internal class TestCreateProject {
 
         val clientBuildGradle = outputDir.resolve("client/build.gradle")
         val clientMainClass = "com.megacorp.client.MegaEnclaveClient"
-        assertTrue(clientBuildGradle.readText().contains("mainClassName = \"$clientMainClass\""))
+        assertThat(clientBuildGradle.readText()).contains("""mainClass.set("$clientMainClass")""")
 
         val hostBuildGradle = outputDir.resolve("host/build.gradle")
         val hostMainClass = "com.r3.conclave.host.web.EnclaveWebHost"
-        assertTrue(hostBuildGradle.readText().contains("mainClassName = \"$hostMainClass\""))
+        assertThat(hostBuildGradle.readText()).contains("""mainClass.set("$hostMainClass")""")
 
         val sourceFiles = outputDir
             .walkTopDown()

--- a/conclave-init/template/client/build.gradle
+++ b/conclave-init/template/client/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 application {
-    mainClassName = "com.r3.conclave.template.client.TemplateEnclaveClient"
+    mainClass.set("com.r3.conclave.template.client.TemplateEnclaveClient")
 }
 
 dependencies {

--- a/conclave-init/template/host/build.gradle
+++ b/conclave-init/template/host/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 // Use the provided main method for the web host.
 application {
-    mainClassName = "com.r3.conclave.host.web.EnclaveWebHost"
+    mainClass.set("com.r3.conclave.host.web.EnclaveWebHost")
 }
 
 // Define a Gradle flag "enclaveMode" which controls which enclave mode to use when building the host. The default is

--- a/docs/docs/writing-your-own-enclave-host.md
+++ b/docs/docs/writing-your-own-enclave-host.md
@@ -35,7 +35,7 @@ Update the host build.gradle to reference it:
 
 ```groovy hl_lines="2"
 application {
-    mainClassName = "com.example.tutorial.host.MyEnclaveHost"
+    mainClass.set("com.example.tutorial.host.MyEnclaveHost")
 }
 ```
 


### PR DESCRIPTION
This stops ugly deprecation warning from being displayed when the project is built.