### PR TITLE
CON-1020: Publish Conclave SDK to Maven Central (fix Sonatype repo address)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -393,6 +393,17 @@ for (publishedProject in publishedProjects) {
             }
         }
         repositories {
+            //  This repository is used for publishing to Maven Central from TeamCity.
+            if (versionType == VersionType.GA_RELEASE) {
+                maven {
+                    name = "OSSRH"
+                    url = "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+                    credentials {
+                        username = System.getenv("CONCLAVE_OSSRH_USERNAME")
+                        password = System.getenv("CONCLAVE_OSSRH_PASSWORD")
+                    }
+                }
+            }
             maven {
                 name = "artifactory"
                 url = getArtifactoryForPublication()
@@ -404,17 +415,6 @@ for (publishedProject in publishedProjects) {
             maven {    // This section implicitly creates the publishAllPublicationsToBuildRepository target.
                 name = "build"
                 url = "$buildDir/repo"
-            }
-            //  This repository is used for publishing to Maven Central from TeamCity.
-            if (versionType == VersionType.GA_RELEASE) {
-                maven {
-                    name = "OSSRH"
-                    url = "https://oss.sonatype.org/service/local/staging/deploy/maven2"
-                    credentials {
-                        username = System.getenv("CONCLAVE_OSSRH_USERNAME")
-                        password = System.getenv("CONCLAVE_OSSRH_PASSWORD")
-                    }
-                }
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -397,7 +397,7 @@ for (publishedProject in publishedProjects) {
             if (versionType == VersionType.GA_RELEASE) {
                 maven {
                     name = "OSSRH"
-                    url = "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+                    url = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2"
                     credentials {
                         username = System.getenv("CONCLAVE_OSSRH_USERNAME")
                         password = System.getenv("CONCLAVE_OSSRH_PASSWORD")

--- a/scripts/ci_publish.sh
+++ b/scripts/ci_publish.sh
@@ -5,4 +5,4 @@ script_dir=$(dirname ${BASH_SOURCE[0]})
 source ${script_dir}/ci_build_common.sh
 
 # Publish. All testing should be done before this, i.e. running ci_build.sh
-runDocker $container_image_sdk_build "./gradlew publishAllPublicationsToArtifactoryRepository -s -i"
+runDocker $container_image_sdk_build "./gradlew publish -s -i"


### PR DESCRIPTION
After the fixes in the PR here https://github.com/R3Conclave/conclave-core-sdk/pull/13 we have got back a 403 error during publication, due to a wrong legacy Sonatype repository address, while we were given access to the newest Sonatype repository.
This patch fixes this.