### PR TITLE
CON-1138: Make links readable on the docs site

### DIFF
--- a/docs/docs/css/r3-branding.css
+++ b/docs/docs/css/r3-branding.css
@@ -13,6 +13,7 @@ See:
   --md-primary-fg-color--light:        #53585F;
   --md-primary-fg-color--dark:         #00161E;
   --md-accent-fg-color:                #EC1D24;
+  --md-typeset-a-color:                #006c94;
 }
 
 :root > * {

--- a/docs/docs/css/r3-branding.css
+++ b/docs/docs/css/r3-branding.css
@@ -13,7 +13,7 @@ See:
   --md-primary-fg-color--light:        #53585F;
   --md-primary-fg-color--dark:         #00161E;
   --md-accent-fg-color:                #EC1D24;
-  --md-typeset-a-color:                #006c94;
+  --md-typeset-a-color:                #338BA8;
 }
 
 :root > * {

--- a/docs/docs/css/r3-branding.css
+++ b/docs/docs/css/r3-branding.css
@@ -13,10 +13,12 @@ See:
   --md-primary-fg-color--light:        #53585F;
   --md-primary-fg-color--dark:         #00161E;
   --md-accent-fg-color:                #EC1D24;
-  --md-typeset-color:                  #ADD8E6;
-  --md-typeset-a-color:                #ADD8E6;
 }
 
 :root > * {
   --md-footer-bg-color:                #003245;
+}
+
+.md-content {
+  --md-typeset-a-color: #ADD8E6;
 }

--- a/docs/docs/css/r3-branding.css
+++ b/docs/docs/css/r3-branding.css
@@ -13,7 +13,8 @@ See:
   --md-primary-fg-color--light:        #53585F;
   --md-primary-fg-color--dark:         #00161E;
   --md-accent-fg-color:                #EC1D24;
-  --md-typeset-a-color:                #338BA8;
+  --md-typeset-color:                  #ADD8E6;
+  --md-typeset-a-color:                #ADD8E6;
 }
 
 :root > * {

--- a/docs/docs/css/r3-branding.css
+++ b/docs/docs/css/r3-branding.css
@@ -20,5 +20,5 @@ See:
 }
 
 .md-content {
-  --md-typeset-a-color: #ADD8E6;
+  --md-typeset-a-color:                #007BA7;
 }


### PR DESCRIPTION
Currently, links are not distinguishable from standard text on the docs site. Only when a user hovers over the link text the user knows it's a link.

I have changed the color of links by adding a CSS variable '--md-typeset-a-color' in the r3-branding.css file.  I have used a lighter version of teal, which wouldn't stand out too much while being readable. The hex color code is #006c94. Needs to test how it looks when published.