### PR TITLE
CON-1144: Change primary color of docs site.

### DIFF
--- a/docs/docs/css/r3-branding.css
+++ b/docs/docs/css/r3-branding.css
@@ -9,14 +9,14 @@ See:
 */
 
 :root {
-  --md-primary-fg-color:               #003245;
-  --md-primary-fg-color--light:        #53585F;
-  --md-primary-fg-color--dark:         #00161E;
+  --md-primary-fg-color:               #191A25;
+  --md-primary-fg-color--light:        #424258;
+  --md-primary-fg-color--dark:         #15151E;
   --md-accent-fg-color:                #EC1D24;
 }
 
 :root > * {
-  --md-footer-bg-color:                #003245;
+  --md-footer-bg-color:                #191A25;
 }
 
 .md-content {


### PR DESCRIPTION
The [new conclave website](https://conclave.webflow.io/) has a new color scheme. This ticket is to match the color of the docs site to the website's color theme.

A screenshot of the new color scheme is given below:

![image](https://user-images.githubusercontent.com/108324937/188578652-b1a1dd82-109b-47a6-a7c2-7ef7c1298bfe.png)
 