### PR TITLE
Mention open source and GitHub repository. Fix a few minor typos.

### DIFF
--- a/docs/docs/api-changes.md
+++ b/docs/docs/api-changes.md
@@ -4,10 +4,10 @@
 
 ### Maven Central
 
-With the open sourcing of the SDK, artifacts are no longer distributed in a zip file and are instead available on 
+With the [open sourcing](https://github.com/R3Conclave/conclave-core-sdk) of the SDK, artifacts are no longer distributed in a zip file and are instead available on 
 [Maven Central](https://search.maven.org/). For existing projects, the local maven repo directory is no longer needed. 
 This can be deleted along with the `conclaveRepo` property in your gradle.properties file. Make sure `mavenCentral()` 
-is added as a repository in your build.gradle:
+is added as a repository in your `build.gradle`:
 
 ```groovy
 subprojects {
@@ -221,7 +221,7 @@ if (mode == "mock") {
 ## Beta 4 to 1.0
 Between beta 4 and 1.0 the API for creating mail has changed. `MutableMail` has been replaced by `PostOffice` which is a
 factory for creating encrypted mail. There's no longer any need to manually increment the sequence number as that's done
-for you. Instead make sure to only have one instance per sender key and topic. This allows the enclave to check for
+for you. Instead, make sure to only have one instance per sender key and topic. This allows the enclave to check for
 dropped or reordered mail. `Mail.decrypt` and `EnclaveInstanceInfo.decryptMail` have been replaced by `PostOffice.decryptMail`.
 Decrypt any response mail using the same post office instance that created the request.
 

--- a/docs/docs/conclave-init.md
+++ b/docs/docs/conclave-init.md
@@ -1,7 +1,7 @@
 # Conclave Init
 
 Conclave Init is a tool for bootstrapping Conclave projects, reducing the amount of boilerplate you need to write.
-It will automatically generate your Conclave project so that you can focus on writing enclave code!
+It will automatically generate your Conclave project so that you can focus on writing enclave code.
 
 ## Generate a new project
 

--- a/docs/docs/conclave-web-host.md
+++ b/docs/docs/conclave-web-host.md
@@ -1,6 +1,6 @@
 # The Conclave web host
 
-By default, Conclave projects use a built in host module that manages your enclave instance and provides a simple 
+By default, Conclave projects use a built-in host module that manages your enclave instance and provides a simple 
 REST API to facilitate communication. The web host is sufficient for simple projects, but more complex projects may 
 require additional functionality not implemented by the web host. In these cases a custom host can be implemented, 
 see [writing your own host](writing-your-own-enclave-host.md) for more information.

--- a/docs/docs/ide-configuration.md
+++ b/docs/docs/ide-configuration.md
@@ -35,7 +35,7 @@ idea {
 }
 ```
 
-Finally apply the same configuration to all subprojects.
+Finally, apply the same configuration to all subprojects.
 
 ```groovy hl_lines="2-13"
 subprojects {

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -21,12 +21,14 @@ With Conclave, you can build:
 ## What is Conclave?
 
 Conclave is a software development kit for the rapid development of privacy-first applications using hardware-based Trusted Execution Environments (TEEs) known as [enclaves](enclaves.md).
-Conclave makes [Confidential Computing](enclaves.md) using Intel® Security Guard Extension (SGX) more accessible for developers.
+Conclave makes [Confidential Computing](enclaves.md) using Intel® Security Guard Extension (SGX) more accessible for 
+developers. Take a look at our source code on [this GitHub repository](https://github.com/R3Conclave/conclave-core-sdk).
 
 ### Advantages of Conclave
 
 - **Developer-friendly:** You don't have to be a cryptography expert to use Conclave. A high-level, intuitive API helps you write secure applications on any operating system.
 - **Code in many languages:** Write your code in Java, Kotlin, or any other JVM (Java Virtual Machine) language. You can also use Javascript and basic Python to write your application.
+- **Open Source:**: You can [verify the source code](https://github.com/R3Conclave/conclave-core-sdk) and remove Conclave from your trust model.
 - **Focus on business logic:** Interact with secure enclaves easily using an intuitive API. **Conclave Mail** takes care of the end-to-end encrypted messaging.
 - **Everything in one platform:** The Core SDK tightly integrates with a
   [complementary cloud offering](https://www.conclave.net/conclave-cloud/).

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -22,7 +22,7 @@ With Conclave, you can build:
 
 Conclave is a software development kit for the rapid development of privacy-first applications using hardware-based Trusted Execution Environments (TEEs) known as [enclaves](enclaves.md).
 Conclave makes [Confidential Computing](enclaves.md) using Intel® Security Guard Extension (SGX) more accessible for 
-developers. Take a look at our source code on [this GitHub repository](https://github.com/R3Conclave/conclave-core-sdk).
+developers. Take a look at the source code on [this GitHub repository](https://github.com/R3Conclave/conclave-core-sdk).
 
 ### Advantages of Conclave
 

--- a/docs/docs/known-issues.md
+++ b/docs/docs/known-issues.md
@@ -1,19 +1,23 @@
 # Known issues
 
-The Conclave API is by now mostly stable, but small changes may still occur. In particular we may adjust mail to support streaming access.
+The Conclave API is by now mostly stable, but small changes may still occur. In particular, we may adjust 
+Conclave Mail to 
+support streaming access.
 You should expect to spend a few minutes updating your code between releases, but not more.
 
 This release ships with the following known issues that we plan to address in future versions:
 
 1. Some system level exceptions like divide by zero or using null reference may crash the enclave/host process.
-1. Opening network sockets doesn't work. We plan to support opening *outbound* sockets in future, but running socket
-   based *servers* inside an enclave is probably not the best way to use enclave technology. Please read about [mail](mail.md)
-   to learn how to send messages to and from an enclave.
-1. Mail is limited in size by the size of the enclave heap, and the size of a Java array (2 gigabytes).
-1. Enclaves built using Conclave currently do not have a stable measurement, meaning that each time you build your enclave you will end up with a different MRSIGNER value.
-1. JavaDocs don't integrate with IntelliJ properly. This is due to a bug in IntelliJ when loading modules from
+2. Opening network sockets doesn't work. We plan to support opening *outbound* sockets in the future, but running 
+   socket-based *servers* inside an enclave is probably not the best way to use enclave technology. Please read 
+   about [Mail](mail.md) to learn how to send messages to and from an enclave.
+3. Mail is limited in size by the size of the enclave heap, and the size of a Java array (2 gigabytes).
+4. Enclaves built using Conclave currently do not have a stable measurement, meaning that each time you build your 
+   enclave you will end up with a different MRSIGNER value.
+5. JavaDocs don't integrate with IntelliJ properly. This is due to a bug in IntelliJ when loading modules from
    on disk repositories.
-1. On Windows and macOS, serialization and reflection configuration files configured as described on
+6. On Windows and macOS, serialization and reflection configuration files configured as described on
    [enclave configuration](enclave-configuration.md) must use non-relative paths. Additionally, on Windows, the paths
    must use forward slashes rather than Windows standard backslashes.
-1. Conclave works *only* in [mock mode](enclave-modes.md#mock-mode) on [new Mac computers with Apple silicon](https://support.apple.com/en-in/HT211814) due to the reliance on x64 binaries.
+7. Conclave works *only* in [mock mode](enclave-modes.md#mock-mode) on
+   [new Mac computers with Apple silicon](https://support.apple.com/en-in/HT211814) due to the reliance on x64 binaries.


### PR DESCRIPTION
- Scanned the docs site for opportunities to mention open-sourcing and link the GitHub repository.
- Mentioned open source and linked to the GitHub repository on a couple of pages, including the homepage.
- Fixed some typos that I noticed while scanning through all the docs.