### PR TITLE
CON-1161 - Integrated gramine Conclave and refactored the code

### DIFF
--- a/conclave-host/src/main/kotlin/com/r3/conclave/host/EnclaveHost.kt
+++ b/conclave-host/src/main/kotlin/com/r3/conclave/host/EnclaveHost.kt
@@ -424,10 +424,10 @@ class EnclaveHost private constructor(
         if (hostStateManager.state is Started) return
         hostStateManager.checkStateIsNot<Closed> { "The host has been closed." }
 
-        // For now, there is no enclave for gramine instead the mock enclave is initialised.
+        // For now, there is no enclave for Gramine instead the mock enclave is initialised.
         // This is OK because no VM is started in Mock mode and this will allow us to integrate Gramine with Conclave
         // iteratively without causing issues to the normal operation of Conclave.
-        // Start gramine only if the environment variable is set
+        // Start Gramine only if the environment variable is set
         if(Gramine.isGramineEnabled())
         {
             if(enclaveHandle !is MockEnclaveHandle) {

--- a/conclave-host/src/main/kotlin/com/r3/conclave/host/EnclaveHost.kt
+++ b/conclave-host/src/main/kotlin/com/r3/conclave/host/EnclaveHost.kt
@@ -126,7 +126,7 @@ class EnclaveHost private constructor(
         @JvmStatic
         @Throws(EnclaveLoadException::class, PlatformSupportException::class)
         fun load(enclaveClassName: String, mockConfiguration: MockConfiguration?): EnclaveHost {
-            return createEnclaveHost(findEnclave(enclaveClassName), mockConfiguration)
+            return createEnclaveHost(EnclaveScanner.findEnclave(enclaveClassName), mockConfiguration)
         }
 
         /**
@@ -146,7 +146,7 @@ class EnclaveHost private constructor(
         @JvmStatic
         @Throws(EnclaveLoadException::class, PlatformSupportException::class)
         fun load(mockConfiguration: MockConfiguration?): EnclaveHost {
-            return createEnclaveHost(findEnclave(), mockConfiguration)
+            return createEnclaveHost(EnclaveScanner.findEnclave(), mockConfiguration)
         }
 
         /**
@@ -234,128 +234,15 @@ class EnclaveHost private constructor(
             return EnclaveHost(enclaveHandle)
         }
 
-        /**
-         * Searches for an enclave. There are two places where an enclave can be found.
-         * 1) In an SGX signed enclave file (.so)
-         * 2) For mock enclaves, an existing class named 'className' in the classpath
-         *
-         * For a .so enclave file the function looks in the classpath at /package/namespace/classname-mode.signed.so.
-         * For example, it will look for the enclave file of "com.foo.bar.Enclave" at /com/foo/bar/Enclave-$mode.signed.so.
-         *
-         * For mock enclaves, the function just determines whether the class specified as 'className' exists.
-         *
-         * If more than one enclave is found (i.e. multiple modes, or mock + signed enclave) then an exception is thrown.
-         *
-         * For .so enclaves, the mode is derived from the filename but is not taken at face value. The construction of the
-         * EnclaveInstanceInfoImpl in `start` makes sure the mode is correct it terms of the remote attestation.
-         */
-        private fun findEnclave(enclaveClassName: String): EnclaveScanResult {
-            val results = ArrayList<EnclaveScanResult>()
-            EnclaveMode.values().mapNotNullTo(results) { findNativeEnclave(enclaveClassName, it) }
-            findMockEnclave(enclaveClassName)?.let { results += it }
-            return getSingleResult(results, enclaveClassName)
-        }
-
-        private fun findNativeEnclave(enclaveClassName: String, enclaveMode: EnclaveMode): EnclaveScanResult.Native? {
-            val resourceName = "/${enclaveClassName.replace('.', '/')}-${enclaveMode.name.lowercase()}.signed.so"
-            val url = EnclaveHost::class.java.getResource(resourceName)
-            return url?.let { EnclaveScanResult.Native(enclaveClassName, enclaveMode, url) }
-        }
-
-        private fun findMockEnclave(enclaveClassName: String): EnclaveScanResult.Mock? {
-            return try {
-                Class.forName(enclaveClassName)
-                EnclaveScanResult.Mock(enclaveClassName)
-            } catch (e: ClassNotFoundException) {
-                null
-            }
-        }
-
-        /**
-         * Performs a search for an enclave by performing a classpath and module scan. There are two places where an enclave
-         * can be found.
-         * 1) In an SGX signed enclave file (.so)
-         * 2) For mock enclaves, an existing class in the classpath
-         *
-         * For a .so enclave file the function looks in the classpath and search for a file name that matches the pattern
-         * ^.*(simulation|debug|release)\.signed\.so$.
-         *
-         * For mock enclaves, the function searches for classes that extend com.r3.conclave.enclave.Enclave.
-         *
-         * If more than one enclave is found (i.e. multiple modes, or mock + signed enclave) then an exception is thrown.
-         *
-         * For .so enclaves, the mode is derived from the filename but is not taken at face value. The construction of the
-         * EnclaveInstanceInfoImpl in `start` makes sure the mode is correct it terms of the remote attestation.
-         *
-         * @return Pair with the class name and URL (if not a mock enclave) of the enclave found.
-         */
-        private fun findEnclave(): EnclaveScanResult {
-            val classGraph = ClassGraph()
-            val results = ArrayList<EnclaveScanResult>()
-            findNativeEnclaves(classGraph, results)
-            findMockEnclaves(classGraph, results)
-            return getSingleResult(results, null)
-        }
-
-        /**
-         * Performs a search for Intel SGX signed enclave files (.so) using ClassGraph.
-         */
-        private fun findNativeEnclaves(classGraph: ClassGraph, results: MutableList<EnclaveScanResult>) {
-            val nativeSoFilePattern = Pattern.compile("""^(.+)-(simulation|debug|release)\.signed\.so$""")
-
-            classGraph.scan().use {
-                for (resource in it.allResources) {
-                    val pathMatcher = nativeSoFilePattern.matcher(resource.path)
-                    if (pathMatcher.matches()) {
-                        val enclaveClassName = pathMatcher.group(1).replace('/', '.')
-                        val enclaveMode = EnclaveMode.valueOf(pathMatcher.group(2).uppercase())
-                        results += EnclaveScanResult.Native(enclaveClassName, enclaveMode, resource.url)
-                    }
-                }
-            }
-        }
-
-        /**
-         * Performs a search for mock enclave files using ClassGraph. The search is performed by looking for classes that
-         * extend com.r3.conclave.enclave.Enclave.
-         */
-        private fun findMockEnclaves(classGraph: ClassGraph, results: MutableList<EnclaveScanResult>) {
-            classGraph.enableClassInfo().scan().use {
-                for (classInfo in it.getSubclasses("com.r3.conclave.enclave.Enclave")) {
-                    if (!classInfo.isAbstract) {
-                        results += EnclaveScanResult.Mock(classInfo.name)
-                    }
-                }
-            }
-        }
-
-        private fun getSingleResult(results: List<EnclaveScanResult>, className: String?): EnclaveScanResult {
-            when (results.size) {
-                1 -> return results[0]
-                0 -> {
-                    val beginning = if (className != null) "Enclave $className does not exist" else "No enclaves found"
-                    throw IllegalArgumentException(
-                        """$beginning on the classpath. Please make sure the gradle dependency to the enclave project is correctly specified:
-                            |    runtimeOnly project(path: ":enclave project", configuration: mode)
-                            |
-                            |    where:
-                            |      mode is either "release", "debug", "simulation" or "mock"
-                            """.trimMargin()
-                    )
-                }
-                else -> throw IllegalStateException("Multiple enclaves were found: $results")
-            }
-        }
-
-        private fun createEnclaveHost(result: EnclaveScanResult, mockConfiguration: MockConfiguration?): EnclaveHost {
+        private fun createEnclaveHost(result: EnclaveScanner.ScanResult, mockConfiguration: MockConfiguration?): EnclaveHost {
             try {
                 return when (result) {
-                    is EnclaveScanResult.Mock -> {
+                    is EnclaveScanner.ScanResult.Mock -> {
                         // Here we do not call checkPlatformEnclaveSupport as mock mode is supported on any platform
                         val enclaveClass = Class.forName(result.enclaveClassName)
                         internalCreateMock(enclaveClass, mockConfiguration)
                     }
-                    is EnclaveScanResult.Native -> {
+                    is EnclaveScanner.ScanResult.Native -> {
                         checkPlatformEnclaveSupport(result.enclaveMode)
                         internalCreateNative(result.enclaveMode, result.soFileUrl, result.enclaveClassName)
                     }
@@ -536,6 +423,18 @@ class EnclaveHost private constructor(
     ) {
         if (hostStateManager.state is Started) return
         hostStateManager.checkStateIsNot<Closed> { "The host has been closed." }
+
+        // For now, there is no enclave for gramine instead the mock enclave is initialised.
+        // This is OK because no VM is started in Mock mode and this will allow us to integrate Gramine with Conclave
+        // iteratively without causing issues to the normal operation of Conclave.
+        // Start gramine only if the environment variable is set
+        if(Gramine.isGramineEnabled())
+        {
+            if(enclaveHandle !is MockEnclaveHandle) {
+                throw Exception("Gramine cannot be started in non-mock modes")
+            }
+            Gramine.start()
+        }
 
         checkAesmAddrEnvVar()
 
@@ -850,6 +749,9 @@ class EnclaveHost private constructor(
 
     @Synchronized
     override fun close() {
+        if(Gramine.isGramineEnabled()) {
+            Gramine.stop()
+        }
         // Closing an unstarted or already closed EnclaveHost is allowed, because this makes it easier to use
         // Java try-with-resources and makes finally blocks more forgiving, e.g.
         //
@@ -1230,20 +1132,139 @@ class EnclaveHost private constructor(
         object Closed : HostState()
     }
 
-    private sealed class EnclaveScanResult {
-        class Mock(val enclaveClassName: String) : EnclaveScanResult() {
-            override fun toString(): String = "mock $enclaveClassName"
+    /**
+     * The following singleton contains the necessary functions to search for enclave classes
+     **/
+    private object EnclaveScanner {
+
+        /**
+         * Performs a search for an enclave by performing a classpath and module scan. There are two places where an enclave
+         * can be found.
+         * 1) In an SGX signed enclave file (.so)
+         * 2) For mock enclaves, an existing class in the classpath
+         *
+         * For a .so enclave file the function looks in the classpath and search for a file name that matches the pattern
+         * ^.*(simulation|debug|release)\.signed\.so$.
+         *
+         * For mock enclaves, the function searches for classes that extend com.r3.conclave.enclave.Enclave.
+         *
+         * If more than one enclave is found (i.e. multiple modes, or mock + signed enclave) then an exception is thrown.
+         *
+         * For .so enclaves, the mode is derived from the filename but is not taken at face value. The construction of the
+         * EnclaveInstanceInfoImpl in `start` makes sure the mode is correct it terms of the remote attestation.
+         *
+         * @return Pair with the class name and URL (if not a mock enclave) of the enclave found.
+         */
+        fun findEnclave(): ScanResult {
+            val classGraph = ClassGraph()
+            val results = ArrayList<ScanResult>()
+            findNativeEnclaves(classGraph, results)
+            findMockEnclaves(classGraph, results)
+            return getSingleResult(results, null)
         }
 
-        class Native(
-            val enclaveClassName: String,
-            val enclaveMode: EnclaveMode,
-            val soFileUrl: URL
-        ) : EnclaveScanResult() {
-            init {
-                require(enclaveMode != EnclaveMode.MOCK)
+        /**
+         * Searches for an enclave. There are two places where an enclave can be found.
+         * 1) In an SGX signed enclave file (.so)
+         * 2) For mock enclaves, an existing class named 'className' in the classpath
+         *
+         * For a .so enclave file the function looks in the classpath at /package/namespace/classname-mode.signed.so.
+         * For example, it will look for the enclave file of "com.foo.bar.Enclave" at /com/foo/bar/Enclave-$mode.signed.so.
+         *
+         * For mock enclaves, the function just determines whether the class specified as 'className' exists.
+         *
+         * If more than one enclave is found (i.e. multiple modes, or mock + signed enclave) then an exception is thrown.
+         *
+         * For .so enclaves, the mode is derived from the filename but is not taken at face value. The construction of the
+         * EnclaveInstanceInfoImpl in `start` makes sure the mode is correct it terms of the remote attestation.
+         */
+        fun findEnclave(enclaveClassName: String): ScanResult {
+            val results = ArrayList<ScanResult>()
+            EnclaveMode.values().mapNotNullTo(results) { findNativeEnclave(enclaveClassName, it) }
+            findMockEnclave(enclaveClassName)?.let { results += it }
+            return getSingleResult(results, enclaveClassName)
+        }
+
+        private fun findNativeEnclave(enclaveClassName: String, enclaveMode: EnclaveMode): ScanResult.Native? {
+            val resourceName = "/${enclaveClassName.replace('.', '/')}-${enclaveMode.name.lowercase()}.signed.so"
+            val url = EnclaveHost::class.java.getResource(resourceName)
+            return url?.let { ScanResult.Native(enclaveClassName, enclaveMode, url) }
+        }
+
+        private fun findMockEnclave(enclaveClassName: String): ScanResult.Mock? {
+            return try {
+                Class.forName(enclaveClassName)
+                ScanResult.Mock(enclaveClassName)
+            } catch (e: ClassNotFoundException) {
+                null
             }
-            override fun toString(): String = "${enclaveMode.name.lowercase()} $enclaveClassName"
+        }
+
+        /**
+         * Performs a search for Intel SGX signed enclave files (.so) using ClassGraph.
+         */
+        private fun findNativeEnclaves(classGraph: ClassGraph, results: MutableList<ScanResult>) {
+            val nativeSoFilePattern = Pattern.compile("""^(.+)-(simulation|debug|release)\.signed\.so$""")
+
+            classGraph.scan().use {
+                for (resource in it.allResources) {
+                    val pathMatcher = nativeSoFilePattern.matcher(resource.path)
+                    if (pathMatcher.matches()) {
+                        val enclaveClassName = pathMatcher.group(1).replace('/', '.')
+                        val enclaveMode = EnclaveMode.valueOf(pathMatcher.group(2).uppercase())
+                        results += ScanResult.Native(enclaveClassName, enclaveMode, resource.url)
+                    }
+                }
+            }
+        }
+
+        /**
+         * Performs a search for mock enclave files using ClassGraph. The search is performed by looking for classes that
+         * extend com.r3.conclave.enclave.Enclave.
+         */
+        private fun findMockEnclaves(classGraph: ClassGraph, results: MutableList<ScanResult>) {
+            classGraph.enableClassInfo().scan().use {
+                for (classInfo in it.getSubclasses("com.r3.conclave.enclave.Enclave")) {
+                    if (!classInfo.isAbstract) {
+                        results += ScanResult.Mock(classInfo.name)
+                    }
+                }
+            }
+        }
+
+        private fun getSingleResult(results: List<ScanResult>, className: String?): ScanResult {
+            when (results.size) {
+                1 -> return results[0]
+                0 -> {
+                    val beginning = if (className != null) "Enclave $className does not exist" else "No enclaves found"
+                    throw IllegalArgumentException(
+                        """$beginning on the classpath. Please make sure the gradle dependency to the enclave project is correctly specified:
+                            |    runtimeOnly project(path: ":enclave project", configuration: mode)
+                            |
+                            |    where:
+                            |      mode is either "release", "debug", "simulation" or "mock"
+                            """.trimMargin()
+                    )
+                }
+                else -> throw IllegalStateException("Multiple enclaves were found: $results")
+            }
+        }
+
+        sealed class ScanResult {
+            class Mock(val enclaveClassName: String) : ScanResult() {
+                override fun toString(): String = "mock $enclaveClassName"
+            }
+
+            class Native(
+                val enclaveClassName: String,
+                val enclaveMode: EnclaveMode,
+                val soFileUrl: URL
+            ) : ScanResult() {
+                init {
+                    require(enclaveMode != EnclaveMode.MOCK)
+                }
+                override fun toString(): String = "${enclaveMode.name.lowercase()} $enclaveClassName"
+            }
         }
     }
 }

--- a/conclave-host/src/main/kotlin/com/r3/conclave/host/Gramine.kt
+++ b/conclave-host/src/main/kotlin/com/r3/conclave/host/Gramine.kt
@@ -1,0 +1,116 @@
+package com.r3.conclave.host
+
+import java.io.File
+import java.io.FileOutputStream
+import java.io.OutputStream
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.TimeUnit
+import kotlin.io.path.absolutePathString
+
+object Gramine {
+
+    private lateinit var processGramineDirect: Process
+
+    fun start() {
+        try {
+            val gramineWorkingDirPath = Files.createTempDirectory("conclave-gramine-runtime")
+            generateManifestFile(gramineWorkingDirPath)
+
+            processGramineDirect = ProcessBuilder()
+                .inheritIO()
+                .directory(File(gramineWorkingDirPath.toUri()))
+                .command("gramine-direct", "bash", "-c", "echo \"Gramine bash \'enclave\' started\" && sleep 10000")
+                .start()
+        } catch (exception: Exception) {
+            exception.printStackTrace();
+        }
+    }
+
+    fun stop() {
+        processGramineDirect.destroy()
+        processGramineDirect.waitFor(10L, TimeUnit.SECONDS)
+        if (processGramineDirect.isAlive) {
+            processGramineDirect.destroyForcibly()
+        }
+    }
+
+    fun isGramineEnabled(): Boolean {
+        val envValue = System.getenv("CONCLAVE_GRAMINE_ENABLE") ?: return false
+        return envValue.uppercase() == "TRUE"
+    }
+
+    private fun generateManifestFile(destination: Path) {
+        val file = File(destination.absolutePathString() + "/" + "bash.manifest")
+        writeToFile(manifestContent.toByteArray(), file)
+    }
+
+    private fun writeToFile(content: ByteArray, file: File) {
+        // Create an output stream to barf to the file
+        val out: OutputStream = FileOutputStream(file)
+        out.write(content, 0, content.size)
+        out.close()
+    }
+
+    private val manifestContent =
+        """[loader]
+entrypoint = "file:/usr/lib/x86_64-linux-gnu/gramine/libsysdb.so"
+log_level = "error"
+insecure__use_cmdline_argv = true
+
+[libos]
+entrypoint = "/usr/bin/bash"
+
+[fs]
+[[fs.mounts]]
+path = "/lib"
+uri = "file:/usr/lib/x86_64-linux-gnu/gramine/runtime/glibc"
+
+[[fs.mounts]]
+path = "/lib/x86_64-linux-gnu"
+uri = "file:/lib/x86_64-linux-gnu"
+
+[[fs.mounts]]
+path = "/usr/lib"
+uri = "file:/usr/lib"
+
+[[fs.mounts]]
+path = "/usr/bin"
+uri = "file:/usr/bin"
+
+[sgx]
+debug = true
+nonpie_binary = true
+enclave_size = "512M"
+thread_num = 4
+allowed_files = [ "file:scripts/",]
+isvprodid = 0
+isvsvn = 0
+remote_attestation = false
+require_avx = false
+require_avx512 = false
+require_mpx = false
+require_pkru = false
+require_amx = false
+support_exinfo = false
+enable_stats = false
+[[sgx.trusted_files]]
+uri = "file:/usr/lib/x86_64-linux-gnu/gramine/libsysdb.so"
+
+[[sgx.trusted_files]]
+uri = "file:/usr/bin/"
+
+[[sgx.trusted_files]]
+uri = "file:/usr/lib/x86_64-linux-gnu/gramine/runtime/glibc/"
+
+[[sgx.trusted_files]]
+uri = "file:/lib/x86_64-linux-gnu/"
+
+[[sgx.trusted_files]]
+uri = "file:/usr//lib/x86_64-linux-gnu/"
+
+[loader.env]
+LD_LIBRARY_PATH = "/lib:/lib/x86_64-linux-gnu:/usr/lib/x86_64-linux-gnu"
+PATH = "/usr/bin"
+"""
+}

--- a/conclave-host/src/main/kotlin/com/r3/conclave/host/Gramine.kt
+++ b/conclave-host/src/main/kotlin/com/r3/conclave/host/Gramine.kt
@@ -5,6 +5,7 @@ import java.io.FileOutputStream
 import java.io.OutputStream
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.Paths
 import java.util.concurrent.TimeUnit
 import kotlin.io.path.absolutePathString
 
@@ -40,16 +41,8 @@ object Gramine {
         return envValue.uppercase() == "TRUE"
     }
 
-    private fun generateManifestFile(destination: Path) {
-        val file = File(destination.absolutePathString() + "/" + "bash.manifest")
-        writeToFile(manifestContent.toByteArray(), file)
-    }
-
-    private fun writeToFile(content: ByteArray, file: File) {
-        // Create an output stream to barf to the file
-        val out: OutputStream = FileOutputStream(file)
-        out.write(content, 0, content.size)
-        out.close()
+    private fun generateManifestFile(dirPath: Path) {
+        Files.write(Paths.get(dirPath.absolutePathString() + "/" + "bash.manifest"), manifestContent.toByteArray())
     }
 
     private val manifestContent =


### PR DESCRIPTION
It is now possible to run Conclave using Gramine but without sgx. This is only experimental and more changes will be added in future commits. To use gramine, Conclave must be built in mock mode and the environment variable CONCLAVE_GRAMINE_ENABLE must be set.

The class EnclaveScanner was created to group together all the functions responsible for searching for enclaves.