### PR TITLE
CON-1170: Review API links

### DIFF
--- a/docs/docs/api-changes.md
+++ b/docs/docs/api-changes.md
@@ -35,9 +35,9 @@ supported but deprecated and will be removed in a future version.
 `IOException`. This can occur if the mail to be delivered was encrypted using a KDS key and the host is unable to 
 retrieve it from the KDS.
 
-Though technically not an API change, the docs for [`PostOffice`](api/-conclave%20-core/com.r3.conclave.mail/-post-office)
-and [`EnclavePostOffice`](api/-conclave%20-core/com.r3.conclave.enclave/-enclave-post-office) have been fixed to state that 
-they are _not_ thread-safe.
+Though technically not an API change, the docs for [`PostOffice`](api/-conclave%20-core/com.r3.conclave.mail/-post-office/index.html)
+and [`EnclavePostOffice`](api/-conclave%20-core/com.r3.conclave.enclave/-enclave-post-office/index.html) have been 
+fixed to state that they are _not_ thread-safe.
 
 ### Conclave Init
 

--- a/docs/docs/architecture.md
+++ b/docs/docs/architecture.md
@@ -219,8 +219,8 @@ In release mode any output to `stdout` and `stderr` is suppressed inside the enc
 
 ### Deployment
 
-You can get SGX capable virtual machines from cloud providers. Currently Microsoft Azure provides the easiest, up to
-date source of SGX VMs. A Conclave host app includes the enclave bundled into the same JAR and the native libraries
+You can get SGX capable virtual machines from cloud providers. Currently, Microsoft Azure provides the easiest, 
+up-to-date source of SGX VMs. A Conclave host app includes the enclave bundled into the same JAR and the native libraries
 required for working with the kernel driver and Intel infrastructure, so you can deploy a Conclave app by simply using
 regular Java deployment procedures. For example, use the Gradle `assemble` plugin to create a tarball/zip of your
 app, or create a fat JAR and copy it to the server.

--- a/docs/docs/renewability.md
+++ b/docs/docs/renewability.md
@@ -60,7 +60,7 @@ Recovery must be a one way door: *new* enclaves should be able to read *old* dat
 to read *new* data.
 
 The current state of the TCB is identified by the SGX CPU Security Version Number (CPUSVN). This is
-an array of bytes that is used to uniquely identify the security state of the the CPU platform, including the CPU SGX
+an array of bytes that is used to uniquely identify the security state of the CPU platform, including the CPU SGX
 microcode revision. Whenever a TCB recovery takes place, the CPUSVN will change. This means that whenever a TCB recovery
 occurs, the CPUSVN changes and all data that is sealed after the recovery will use a new key. 
 
@@ -119,7 +119,7 @@ unexpectedly breaking on the day of the security announcements.
 
 ## CPU Security Version Number
 The current security revision of an Intel SGX platform is identified by the CPU Security Version Number (CPUSVN). This is
-an array of bytes that is used to uniquely identify the security state of the the CPU platform, including the CPU SGX
+an array of bytes that is used to uniquely identify the security state of the CPU platform, including the CPU SGX
 microcode version. Whenever a TCB recovery takes place, the CPUSVN will change.
 
 The CPUSVN is used (along with other parameters) to derive the keys used to seal data that is sent outside the enclave.


### PR DESCRIPTION
When a user clicks on some API links on the docs site, the pages don't render correctly. I investigated all the API links on our docs site and fixed the ones which were not displaying correctly—also fixed a few typos that caught my eye. Note that this is not a thorough rewrite of the docs that are changed by this PR.