### PR TITLE
CON-806 - Review INSECURE, STALE, and SECURE enclave constraint options

### DIFF
--- a/conclave-common/src/main/kotlin/com/r3/conclave/common/EnclaveConstraint.kt
+++ b/conclave-common/src/main/kotlin/com/r3/conclave/common/EnclaveConstraint.kt
@@ -145,7 +145,7 @@ class EnclaveConstraint {
     }
 
     private fun checkSecurityLevel(enclave: EnclaveInstanceInfo) {
-        // If the security level required by the client is insecure than the enclave security should be insecure. This prevents
+        // If the security level required by the client is insecure then the enclave security must be insecure. This prevents
         // clients from connecting to enclaves running in production by mistake. This also stops a malicious host from connecting
         // a client to a production enclave in order to corrupt data. Check CON-806 for more details
         if (minSecurityLevel == EnclaveSecurityInfo.Summary.INSECURE) {

--- a/conclave-common/src/main/kotlin/com/r3/conclave/common/EnclaveConstraint.kt
+++ b/conclave-common/src/main/kotlin/com/r3/conclave/common/EnclaveConstraint.kt
@@ -146,7 +146,8 @@ class EnclaveConstraint {
 
     private fun checkSecurityLevel(enclave: EnclaveInstanceInfo) {
         // If the security level required by the client is insecure than the enclave security should be insecure. This prevents
-        // clients from connecting to enclaves running in production by mistake.
+        // clients from connecting to enclaves running in production by mistake. This also stops a malicious host from connecting
+        // a client to a production enclave in order to corrupt data. Check CON-806 for more details
         if (minSecurityLevel == EnclaveSecurityInfo.Summary.INSECURE) {
             checkEnclave(enclave.securityInfo.summary == minSecurityLevel) {
                 "Enclave has a security level of ${enclave.securityInfo.summary} which does not match the required level of $minSecurityLevel."

--- a/conclave-common/src/main/kotlin/com/r3/conclave/common/EnclaveConstraint.kt
+++ b/conclave-common/src/main/kotlin/com/r3/conclave/common/EnclaveConstraint.kt
@@ -134,14 +134,26 @@ class EnclaveConstraint {
             }
         }
 
-        checkEnclave(enclave.securityInfo.summary >= minSecurityLevel) {
-            "Enclave has a security level of ${enclave.securityInfo.summary} which is lower than the required level of $minSecurityLevel."
-        }
+        checkSecurityLevel(enclave)
 
         maxAttestationAge?.let {
             val earliestAllowedAttestation = ZonedDateTime.now() - maxAttestationAge
             checkEnclave(earliestAllowedAttestation.toInstant().isBefore(enclave.securityInfo.timestamp)) {
                 "Enclave attestation data is out of date with an age that exceeds ${maxAttestationAge}."
+            }
+        }
+    }
+
+    private fun checkSecurityLevel(enclave: EnclaveInstanceInfo) {
+        // If the security level required by the client is insecure than the enclave security should be insecure. This prevents
+        // clients from connecting to enclaves running in production by mistake.
+        if (minSecurityLevel == EnclaveSecurityInfo.Summary.INSECURE) {
+            checkEnclave(enclave.securityInfo.summary == minSecurityLevel) {
+                "Enclave has a security level of ${enclave.securityInfo.summary} which does not match the required level of $minSecurityLevel."
+            }
+        } else {
+            checkEnclave(enclave.securityInfo.summary >= minSecurityLevel) {
+                "Enclave has a security level of ${enclave.securityInfo.summary} which is lower than the required level of $minSecurityLevel."
             }
         }
     }


### PR DESCRIPTION
Updated how the security level is assess. If the security level is set to INSECURE then a client can only communicate with an enclave that is running as INSECURE. If the security level is set to STALE then the client can communicate with a STALE or SECURE enclave. If the security level is set to SECURE then the client can only communicate with a SECURE enclave. This prevents clients from connecting to enclaves running in production by mistake or by a malicious host. Check CON-806 for more details.

Updated the unit-tests file.