### PR TITLE
[CON-861] [CON-862] Stop symlinks/hardlinks from causing enclave crash

### DIFF
--- a/cpp/jvm-enclave-common/stubs/unistd.cpp
+++ b/cpp/jvm-enclave-common/stubs/unistd.cpp
@@ -16,11 +16,21 @@ STUB(pathconf);
 STUB(readlink);
 STUB(_exit);
 STUB(lchown);
-STUB(symlink);
 STUB(__xmknod);
-STUB(link);
 
 extern "C" {
+
+    // The enclave filesystem does not support symbolic links
+    int symlink(const char *path1, const char *path2) {
+        errno = EPERM;
+        return -1;
+    }
+
+    // The enclave filesystem does not support hard links
+    int link(const char *path1, const char *path2) {
+        errno = EPERM;
+        return -1;
+    }
 
     // These two symbols are defined as parameters to the linker when running native-image.
     // __ImageBase is a symbol that is at the address at the base of the image. __HeapSize is


### PR DESCRIPTION
# Changes
- Attempts to create symlinks or hardlinks inside the enclave will no longer cause the enclave to crash. An exception is thrown to the user instead.

# Example stack trace:
```
java.nio.file.FileSystemException: (symlink|link) -> <link-directory>: 
    at sun.nio.fs.UnixFileSystemProvider.createLink(UnixFileSystemProvider.java:491)
    at java.nio.file.Files.createLink(Files.java:1112)
    at com.r3.conclave.sample.enclave.ReverseEnclave.onStartup(ReverseEnclave.java:23)
    at com.r3.conclave.enclave.Enclave$StartCallHandler.handleCall(Enclave.kt:580)
    at com.r3.conclave.common.internal.CallInterface.handleIncomingCall(CallInterface.kt:48)
    at com.r3.conclave.enclave.internal.NativeEnclaveHostInterface.handleCallECall(NativeEnclaveHostInterface.kt:93)
    at com.r3.conclave.enclave.internal.NativeEnclaveHostInterface.handleECall(NativeEnclaveHostInterface.kt:64)
    at com.r3.conclave.enclave.internal.NativeEnclaveEnvironment$Companion.enclaveEntry(NativeEnclaveEnvironment.kt:58)
    at com.r3.conclave.enclave.internal.NativeEnclaveEnvironment.enclaveEntry(NativeEnclaveEnvironment.kt)
    at com.r3.conclave.enclave.internal.substratevm.EntryPoint.entryPoint(EntryPoint.java:23)
```