### PR TITLE
CON-1133, CON-1188: Make stubbed functions to return an error

### DIFF
--- a/cpp/jvm-enclave-common/stubs/dlfcn.cpp
+++ b/cpp/jvm-enclave-common/stubs/dlfcn.cpp
@@ -10,35 +10,35 @@
 
 using namespace std;
 
-//////////////////////////////////////////////////////////////////////////////
-// Stub functions to satisfy the linker
-STUB(dlclose);
-
 extern "C" {
 
-void *dlopen(const char *filename, int flags) {
-    enclave_trace("dlopen\n");
-    return nullptr;
-}
+    void *dlopen(const char *filename, int flags) {
+        enclave_trace("dlopen\n");
+        return nullptr;
+    }
 
-void *dlmopen(const char *filename, int flags) {
-    enclave_trace("dlmopen\n");
-    return nullptr;
-}
+    void *dlmopen(const char *filename, int flags) {
+        enclave_trace("dlmopen\n");
+        return nullptr;
+    }
 
-char *dlerror(){
-    enclave_trace("dlerror\n");
-    return nullptr;
-}
+    char *dlerror(){
+        enclave_trace("dlerror\n");
+        return nullptr;
+    }
 
-int dlinfo(void *handle, int request, void *info) {
-    enclave_trace("dlinfo\n");
-    return -1;
-}
+    int dlinfo(void *handle, int request, void *info) {
+        enclave_trace("dlinfo\n");
+        return -1;
+    }
 
-int dladdr(void* addr, Dl_info* info) {
-    enclave_trace("dladdr\n");
-    return 0;
-}
+    int dladdr(void* addr, Dl_info* info) {
+        enclave_trace("dladdr\n");
+        return 0;
+    }
 
+    int dlclose(void *handle) {
+        enclave_trace("dlclose\n");
+        return -1;
+    }
 }

--- a/cpp/jvm-enclave-common/stubs/ioctl.cpp
+++ b/cpp/jvm-enclave-common/stubs/ioctl.cpp
@@ -3,10 +3,11 @@
 //
 #include "vm_enclave_layer.h"
 
-//////////////////////////////////////////////////////////////////////////////
-// Stub functions to satisfy the linker
-STUB(ioctl);
-
 extern "C" {
 
+    int ioctl(int fd, unsigned long request, ...) {
+        enclave_trace("ioctl\n");
+        errno = EBADF;
+        return -1;
+    }
 }

--- a/cpp/jvm-enclave-common/stubs/ioctl.cpp
+++ b/cpp/jvm-enclave-common/stubs/ioctl.cpp
@@ -7,7 +7,7 @@ extern "C" {
 
     int ioctl(int fd, unsigned long request, ...) {
         enclave_trace("ioctl\n");
-        errno = EBADF;
+        errno = ENOSYS;
         return -1;
     }
 }

--- a/cpp/jvm-enclave-common/stubs/stdio.cpp
+++ b/cpp/jvm-enclave-common/stubs/stdio.cpp
@@ -153,6 +153,6 @@ extern "C" {
 
     char *fgets(char *s, int size, FILE *stream) {
         enclave_trace("fgets\n");
-        return NULL;
+        return nullptr;
     }
 }

--- a/cpp/jvm-enclave-common/stubs/stdio.cpp
+++ b/cpp/jvm-enclave-common/stubs/stdio.cpp
@@ -4,10 +4,6 @@
 #include "vm_enclave_layer.h"
 #include "file_manager.h"
 
-//////////////////////////////////////////////////////////////////////////////
-// Stub functions to satisfy the linker
-STUB(fgets);
-
 extern "C" {
 
     FILE *stdin = nullptr;
@@ -154,4 +150,9 @@ extern "C" {
         }
         return res;   
     }    
+
+    char *fgets(char *s, int size, FILE *stream) {
+        enclave_trace("fgets\n");
+        return NULL;
+    }
 }

--- a/cpp/jvm-enclave-common/stubs/sys_poll.cpp
+++ b/cpp/jvm-enclave-common/stubs/sys_poll.cpp
@@ -8,7 +8,7 @@ extern "C" {
     typedef unsigned long int nfds_t;
 
     int poll(struct pollfd *fds, nfds_t nfds, int timeout) {
-        errno = ENOMEM;
+        errno = ENOSYS;
         return -1;
     }
 }

--- a/cpp/jvm-enclave-common/stubs/sys_poll.cpp
+++ b/cpp/jvm-enclave-common/stubs/sys_poll.cpp
@@ -3,9 +3,12 @@
 //
 #include "vm_enclave_layer.h"
 
-//////////////////////////////////////////////////////////////////////////////
-// Stub functions to satisfy the linker
-STUB(poll);
-
 extern "C" {
+
+    typedef unsigned long int nfds_t;
+
+    int poll(struct pollfd *fds, nfds_t nfds, int timeout) {
+        errno = ENOMEM;
+        return -1;
+    }
 }

--- a/cpp/jvm-enclave-common/stubs/sys_socket.cpp
+++ b/cpp/jvm-enclave-common/stubs/sys_socket.cpp
@@ -6,7 +6,7 @@
 extern "C" {
 
     int socketpair(int domain, int type, int protocol, int sv[2]) {
-	    return socketpair_impl(domain, type, protocol, sv);
+        return socketpair_impl(domain, type, protocol, sv);
     }
 
     int accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen) {
@@ -101,7 +101,7 @@ extern "C" {
 
     int socket(int domain, int type, int protocol) {
         enclave_trace("socket\n");
-        errno = ENOACCES;
+        errno = EACCES;
         return -1;        
     }
 }

--- a/cpp/jvm-enclave-common/stubs/sys_socket.cpp
+++ b/cpp/jvm-enclave-common/stubs/sys_socket.cpp
@@ -3,12 +3,10 @@
 //
 #include "vm_enclave_layer.h"
 
-STUB(socket);
-
 extern "C" {
 
     int socketpair(int domain, int type, int protocol, int sv[2]) {
-	return socketpair_impl(domain, type, protocol, sv);
+	    return socketpair_impl(domain, type, protocol, sv);
     }
 
     int accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen) {

--- a/cpp/jvm-enclave-common/stubs/sys_socket.cpp
+++ b/cpp/jvm-enclave-common/stubs/sys_socket.cpp
@@ -3,20 +3,6 @@
 //
 #include "vm_enclave_layer.h"
 
-//////////////////////////////////////////////////////////////////////////////
-// Stub functions to satisfy the linker
-STUB(accept);
-STUB(bind);
-STUB(connect);
-STUB(getsockname);
-STUB(getsockopt);
-STUB(listen);
-STUB(recv);
-STUB(recvfrom);
-STUB(send);
-STUB(sendto);
-STUB(setsockopt);
-STUB(shutdown);
 STUB(socket);
 
 extern "C" {
@@ -25,4 +11,99 @@ extern "C" {
 	return socketpair_impl(domain, type, protocol, sv);
     }
 
+    int accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen) {
+        enclave_trace("accept\n");
+        errno = EINVAL;
+        return - 1;
+    }
+    
+    int bind(int sockfd, const struct sockaddr *addr, socklen_t addrlen) {
+        enclave_trace("bind\n");
+        errno = EINVAL;
+        return -1;
+    }
+
+    int connect(int sockfd, const struct sockaddr *addr,
+                socklen_t addrlen) {
+        enclave_trace("connect\n");
+        errno = EBADF;
+        return -1;
+    }
+
+    int getsockname(int sockfd, struct sockaddr *addr, socklen_t *addrlen) {
+        enclave_trace("getsockname\n");
+        errno = EBADF;
+        return -1;
+    }
+
+    int getsockopt(int sockfd, int level, int optname,
+                   void *optval, socklen_t *optlen) {
+        enclave_trace("getsockopt\n");
+        errno = EBADF;
+        return -1;
+    }
+    
+    int setsockopt(int sockfd, int level, int optname,
+                   const void *optval, socklen_t optlen) {
+        enclave_trace("setsockopt\n");
+        errno = EBADF;        
+        return -1;
+    }
+
+    int listen(int sockfd, int backlog) {
+        enclave_trace("listen\n");
+        errno = EBADF;
+        return -1;
+    }
+
+    ssize_t recv(int sockfd, void *buf, size_t len, int flags) {
+        enclave_trace("recv\n");
+        errno = EBADF;
+        return -1;
+    }
+
+    ssize_t recvfrom(int sockfd, void *buf, size_t len, int flags,
+                     struct sockaddr *src_addr, socklen_t *addrlen) {
+        enclave_trace("recvfrom\n");
+        errno = EBADF;
+        return -1;
+    }
+    
+    ssize_t recvmsg(int sockfd, struct msghdr *msg, int flags) {
+        enclave_trace("recvmsg\n");
+        errno = EBADF;
+        return -1;
+    }
+
+
+    ssize_t send(int sockfd, const void *buf, size_t len, int flags) {
+        enclave_trace("send\n");
+        errno = EBADF;
+        return -1;
+    }
+
+    ssize_t sendto(int sockfd, const void *buf, size_t len, int flags,
+                   const struct sockaddr *dest_addr, socklen_t addrlen) {
+        enclave_trace("sendto\n");
+        errno = EBADF;
+        return -1;
+    }
+    
+    ssize_t sendmsg(int sockfd, const struct msghdr *msg, int flags) {
+        enclave_trace("sendmsg\n");
+        errno = EBADF;
+        return -1;
+    }
+
+    int shutdown(int sockfd, int how) {
+        enclave_trace("shutdown\n");
+        errno = EBADF;
+        return -1;
+    }
+
+    int socket(int domain, int type, int protocol) {
+        enclave_trace("socket\n");
+        errno = ENOACCES;
+        return -1;        
+    }
 }

--- a/cpp/jvm-enclave-common/stubs/sys_socket.cpp
+++ b/cpp/jvm-enclave-common/stubs/sys_socket.cpp
@@ -11,97 +11,97 @@ extern "C" {
 
     int accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen) {
         enclave_trace("accept\n");
-        errno = EINVAL;
+        errno = ENOSYS;
         return - 1;
     }
     
     int bind(int sockfd, const struct sockaddr *addr, socklen_t addrlen) {
         enclave_trace("bind\n");
-        errno = EINVAL;
+        errno = ENOSYS;
         return -1;
     }
 
     int connect(int sockfd, const struct sockaddr *addr,
                 socklen_t addrlen) {
         enclave_trace("connect\n");
-        errno = EBADF;
+        errno = ENOSYS;
         return -1;
     }
 
     int getsockname(int sockfd, struct sockaddr *addr, socklen_t *addrlen) {
         enclave_trace("getsockname\n");
-        errno = EBADF;
+        errno = ENOSYS;
         return -1;
     }
 
     int getsockopt(int sockfd, int level, int optname,
                    void *optval, socklen_t *optlen) {
         enclave_trace("getsockopt\n");
-        errno = EBADF;
+        errno = ENOSYS;
         return -1;
     }
     
     int setsockopt(int sockfd, int level, int optname,
                    const void *optval, socklen_t optlen) {
         enclave_trace("setsockopt\n");
-        errno = EBADF;        
+        errno = ENOSYS;
         return -1;
     }
 
     int listen(int sockfd, int backlog) {
         enclave_trace("listen\n");
-        errno = EBADF;
+        errno = ENOSYS;
         return -1;
     }
 
     ssize_t recv(int sockfd, void *buf, size_t len, int flags) {
         enclave_trace("recv\n");
-        errno = EBADF;
+        errno = ENOSYS;
         return -1;
     }
 
     ssize_t recvfrom(int sockfd, void *buf, size_t len, int flags,
                      struct sockaddr *src_addr, socklen_t *addrlen) {
         enclave_trace("recvfrom\n");
-        errno = EBADF;
+        errno = ENOSYS;
         return -1;
     }
     
     ssize_t recvmsg(int sockfd, struct msghdr *msg, int flags) {
         enclave_trace("recvmsg\n");
-        errno = EBADF;
+        errno = ENOSYS;
         return -1;
     }
 
 
     ssize_t send(int sockfd, const void *buf, size_t len, int flags) {
         enclave_trace("send\n");
-        errno = EBADF;
+        errno = ENOSYS;
         return -1;
     }
 
     ssize_t sendto(int sockfd, const void *buf, size_t len, int flags,
                    const struct sockaddr *dest_addr, socklen_t addrlen) {
         enclave_trace("sendto\n");
-        errno = EBADF;
+        errno = ENOSYS;
         return -1;
     }
     
     ssize_t sendmsg(int sockfd, const struct msghdr *msg, int flags) {
         enclave_trace("sendmsg\n");
-        errno = EBADF;
+        errno = ENOSYS;
         return -1;
     }
 
     int shutdown(int sockfd, int how) {
         enclave_trace("shutdown\n");
-        errno = EBADF;
+        errno = ENOSYS;
         return -1;
     }
 
     int socket(int domain, int type, int protocol) {
         enclave_trace("socket\n");
-        errno = EACCES;
+        errno = ENOSYS;
         return -1;        
     }
 }

--- a/cpp/jvm-enclave-common/stubs/sys_stat.cpp
+++ b/cpp/jvm-enclave-common/stubs/sys_stat.cpp
@@ -8,94 +8,116 @@
 
 //////////////////////////////////////////////////////////////////////////////
 // Stub functions to satisfy the linker
-STUB(fstat64);
-STUB(fstat);
-STUB(stat);
-STUB(statvfs64);
 STUB(umask);
 
 extern "C" {
 
-	int stat64(const char* pathname, struct stat64*) {
+    int stat64(const char* pathname, struct stat64*) {
 
-		if (pathname[0] == '[') {
-			// stat64("[embedded_foo_jar]")
-			return -1;
-		}
-		jni_throw("STUB: stat64(%s)\n", pathname);
-		return -1;
-	}
+        if (pathname[0] == '[') {
+            // stat64("[embedded_foo_jar]")
+            return -1;
+        }
+        jni_throw("STUB: stat64(%s)\n", pathname);
+        return -1;
+    }
 
-	int __fxstat64(int ver, int fildes, struct stat64* stat_buf) {
-		enclave_trace("__fxstat64\n");
+    int __fxstat64(int ver, int fildes, struct stat64* stat_buf) {
+        enclave_trace("__fxstat64\n");
 
-		// See if this is one of our handled files
-		conclave::File* file = conclave::FileManager::instance().fromHandle(fildes);
-		if (file) {
-			memset(stat_buf, 0, sizeof(struct stat64));
-			stat_buf->st_mode = S_IFMT;
-			return 0;
-		}
-		int err = 0;
-		const int res = __fxstat64_impl(ver, fildes, stat_buf, err);
-		errno = err;
-		return res;
-	}
+        // See if this is one of our handled files
+        conclave::File* file = conclave::FileManager::instance().fromHandle(fildes);
+        if (file) {
+            memset(stat_buf, 0, sizeof(struct stat64));
+            stat_buf->st_mode = S_IFMT;
+            return 0;
+        }
+        int err = 0;
+        const int res = __fxstat64_impl(ver, fildes, stat_buf, err);
+        errno = err;
+        return res;
+    }
 
-	int __xstat64(int ver, const char* path, struct stat64* stat_buf) {
-		enclave_trace("__xstat64\n");
-		int err = 0;
-		const int res = __xstat64_impl(ver, path, stat_buf, err);
-		errno = err;
-		return res;
-	}
+    int __xstat64(int ver, const char* path, struct stat64* stat_buf) {
+        enclave_trace("__xstat64\n");
+        int err = 0;
+        const int res = __xstat64_impl(ver, path, stat_buf, err);
+        errno = err;
+        return res;
+    }
 
-	int mkdir(const char* path, mode_t mode) {
-		enclave_trace("mkdir\n");
-		int err = 0;
-		int res = mkdir_impl(path, mode, err);
-		errno = err;
-		return res;
-	}
+    int mkdir(const char* path, mode_t mode) {
+        enclave_trace("mkdir\n");
+        int err = 0;
+        int res = mkdir_impl(path, mode, err);
+        errno = err;
+        return res;
+    }
 
-	int __xstat(int, const char*, struct stat*) {
-		enclave_trace("__xstat\n");
-		return -1;
-	}
-
-	int __fxstat(int, int, struct stat*) {
-		enclave_trace("__fxstat\n");
-		return -1;
-	}
-
-	int __lxstat(int ver, const char* pathname, struct stat* stat_buf) {
-		enclave_trace("__lxstat\n");
-		int err = 0;
-		const int res = lstat_impl(pathname, stat_buf, err);
-		errno = err;
-		return res;
-	}
+    int __lxstat(int ver, const char* pathname, struct stat* stat_buf) {
+        enclave_trace("__lxstat\n");
+        int err = 0;
+        const int res = lstat_impl(pathname, stat_buf, err);
+        errno = err;
+        return res;
+    }
 
 
-	int __lxstat64(int, const char* pathname, struct stat64* stat_buf) {
-		enclave_trace("__lxstat64\n");
-		int err = 0;
-		const int res = lstat64_impl(pathname, stat_buf, err);
-		errno = err;
-		return res;
-	}
+    int __lxstat64(int, const char* pathname, struct stat64* stat_buf) {
+        enclave_trace("__lxstat64\n");
+        int err = 0;
+        const int res = lstat64_impl(pathname, stat_buf, err);
+        errno = err;
+        return res;
+    }
 
+    // Stub functions to satisfy the linker    
+    int __xstat(int, const char*, struct stat*) {
+        enclave_trace("__xstat\n");
+	errno = EACCES;
+        return -1;
+    }
 
-	int lstat64(const char* pathname, struct stat64* stat_buf) {
-		enclave_trace("lstat\n");
-		int err = 0;
-		const int res = lstat64_impl(pathname, stat_buf, err);
-		errno = err;
-		return res;
-	}
+    int __fxstat(int, int, struct stat*) {
+        enclave_trace("__fxstat\n");
+	errno = EACCES;
+        return -1;
+    }
 
-	int chmod(const char *pathname, mode_t mode) {
-		enclave_trace("chmod\n");
-		return 0;
-	}
+    int lstat64(const char* pathname, struct stat64* stat_buf) {
+        enclave_trace("lstat64\n");
+        int err = 0;
+        const int res = lstat64_impl(pathname, stat_buf, err);
+        errno = err;
+        return res;
+    }
+
+    int chmod(const char *pathname, mode_t mode) {
+        enclave_trace("chmod\n");
+        return 0;
+    }
+
+    int fstat(int fd, struct stat *statbuf) {
+        enclave_trace("fstat\n");
+        errno = EACCES;
+        return -1;
+    }
+
+    int stat(const char *pathname, struct stat *statbuf) {
+        enclave_trace("stat\n");
+        errno = EACCES;
+        return -1;
+    }
+
+    int lstat(const char *pathname, struct stat *statbuf) {
+        enclave_trace("lstat\n");
+        errno = EACCES;
+        return -1;
+    }
+
+    int statvfs64 (const char *file, struct statvfs64 *buf) {
+        enclave_trace("statvfs64\n");
+        errno = EACCES;
+        return -1;
+    }    
 }

--- a/cpp/jvm-enclave-common/stubs/sys_stat.cpp
+++ b/cpp/jvm-enclave-common/stubs/sys_stat.cpp
@@ -74,13 +74,13 @@ extern "C" {
     // Stub functions to satisfy the linker    
     int __xstat(int, const char*, struct stat*) {
         enclave_trace("__xstat\n");
-	errno = EACCES;
+	    errno = ENOSYS;
         return -1;
     }
 
     int __fxstat(int, int, struct stat*) {
         enclave_trace("__fxstat\n");
-	errno = EACCES;
+	    errno = ENOSYS;
         return -1;
     }
 
@@ -99,25 +99,25 @@ extern "C" {
 
     int fstat(int fd, struct stat *statbuf) {
         enclave_trace("fstat\n");
-        errno = EACCES;
+        errno = ENOSYS;
         return -1;
     }
 
     int stat(const char *pathname, struct stat *statbuf) {
         enclave_trace("stat\n");
-        errno = EACCES;
+        errno = ENOSYS;
         return -1;
     }
 
     int lstat(const char *pathname, struct stat *statbuf) {
         enclave_trace("lstat\n");
-        errno = EACCES;
+        errno = ENOSYS;
         return -1;
     }
 
     int statvfs64 (const char *file, struct statvfs64 *buf) {
         enclave_trace("statvfs64\n");
-        errno = EACCES;
+        errno = ENOSYS;
         return -1;
     }    
 }

--- a/cpp/jvm-enclave-common/stubs/unistd.cpp
+++ b/cpp/jvm-enclave-common/stubs/unistd.cpp
@@ -335,50 +335,50 @@ extern "C" {
 
     int gethostname(char *name, size_t len) {
         enclave_trace("gethostname\n");
-        errno = EFAULT;
+        errno = ENOSYS;
         return -1;
     }
 
     int sethostname(const char *name, size_t len) {
         enclave_trace("sethostname\n");
-        errno = EFAULT;
+        errno = ENOSYS;
         return -1;
     }
 
     off_t lseek(int fd, off_t offset, int whence) {
         enclave_trace("lseek\n");
-        errno = EBADF;
+        errno = ENOSYS;
         return -1;
     }
 
     long fpathconf(int fd, int name) {
         enclave_trace("fpathconf\n");
-        errno = EBADF;
+        errno = ENOSYS;
         return -1;
     }
 
     long pathconf(const char *path, int name) {
         enclave_trace("pathconf\n");
-        errno = EACCES;
+        errno = ENOSYS;
         return -1;
     }
 
     ssize_t readlink(const char *pathname, char *buf, size_t bufsiz) {
         enclave_trace("readlink\n");
-        errno = EACCES;
+        errno = ENOSYS;
         return -1;
     }
 
     ssize_t readlinkat(int dirfd, const char *pathname,
                        char *buf, size_t bufsiz) {
         enclave_trace("readlinkat\n");
-        errno = EBADF;
+        errno = ENOSYS;
         return -1;
     }
 
     int lchown(const char *pathname, uid_t owner, gid_t group) {  
         enclave_trace("lchown\n");
-        errno = EPERM;
+        errno = ENOSYS;
         return -1;
     }
 }

--- a/cpp/jvm-enclave-common/stubs/unistd.cpp
+++ b/cpp/jvm-enclave-common/stubs/unistd.cpp
@@ -368,14 +368,14 @@ extern "C" {
         errno = EACCES;
         return -1;
     }
-    
+
     ssize_t readlinkat(int dirfd, const char *pathname,
                        char *buf, size_t bufsiz) {
         enclave_trace("readlinkat\n");
         errno = EBADF;
         return -1;
     }
-            
+
     int lchown(const char *pathname, uid_t owner, gid_t group) {  
         enclave_trace("lchown\n");
         errno = EPERM;

--- a/cpp/jvm-enclave-common/stubs/unistd.cpp
+++ b/cpp/jvm-enclave-common/stubs/unistd.cpp
@@ -10,12 +10,7 @@
 STUB(getegid);
 STUB(geteuid);
 STUB(getgid);
-STUB(gethostname);
-STUB(lseek);
-STUB(pathconf);
-STUB(readlink);
 STUB(_exit);
-STUB(lchown);
 STUB(__xmknod);
 
 extern "C" {
@@ -336,5 +331,54 @@ extern "C" {
         const int res = fchmod_impl(fd, mode, err);
         errno = err;
         return res;
+    }
+
+    int gethostname(char *name, size_t len) {
+        enclave_trace("gethostname\n");
+        errno = EFAULT;
+        return -1;
+    }
+
+    int sethostname(const char *name, size_t len) {
+        enclave_trace("sethostname\n");
+        errno = EFAULT;
+        return -1;
+    }
+
+    off_t lseek(int fd, off_t offset, int whence) {
+        enclave_trace("lseek\n");
+        errno = EBADF;
+        return -1;
+    }
+
+    long fpathconf(int fd, int name) {
+        enclave_trace("fpathconf\n");
+        errno = EBADF;
+        return -1;
+    }
+
+    long pathconf(const char *path, int name) {
+        enclave_trace("pathconf\n");
+        errno = EACCES;
+        return -1;
+    }
+
+    ssize_t readlink(const char *pathname, char *buf, size_t bufsiz) {
+        enclave_trace("readlink\n");
+        errno = EACCES;
+        return -1;
+    }
+    
+    ssize_t readlinkat(int dirfd, const char *pathname,
+                       char *buf, size_t bufsiz) {
+        enclave_trace("readlinkat\n");
+        errno = EBADF;
+        return -1;
+    }
+            
+    int lchown(const char *pathname, uid_t owner, gid_t group) {  
+        enclave_trace("lchown\n");
+        errno = EPERM;
+        return -1;
     }
 }

--- a/integration-tests/general/common/src/main/kotlin/com/r3/conclave/integrationtests/general/common/tasks/CreateSocket.kt
+++ b/integration-tests/general/common/src/main/kotlin/com/r3/conclave/integrationtests/general/common/tasks/CreateSocket.kt
@@ -1,0 +1,19 @@
+package com.r3.conclave.integrationtests.general.common.tasks
+
+import com.r3.conclave.integrationtests.general.common.EnclaveContext
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.serializer
+import java.net.ServerSocket
+
+@Serializable
+class CreateSocket : EnclaveTestAction<Unit>() {
+    override fun run(context: EnclaveContext, isMail: Boolean) {
+
+        val server = ServerSocket(9999)
+        val socket = server.accept()
+
+    }
+
+    override fun resultSerializer(): KSerializer<Unit> = Unit.serializer()
+}

--- a/integration-tests/general/common/src/main/kotlin/com/r3/conclave/integrationtests/general/common/tasks/CreateSocket.kt
+++ b/integration-tests/general/common/src/main/kotlin/com/r3/conclave/integrationtests/general/common/tasks/CreateSocket.kt
@@ -8,7 +8,7 @@ import java.net.ServerSocket
 
 @Serializable
 class CreateSocket : EnclaveTestAction<Unit>() {
-    
+
     override fun run(context: EnclaveContext, isMail: Boolean) {
         val server = ServerSocket(9999)
         val socket = server.accept()

--- a/integration-tests/general/common/src/main/kotlin/com/r3/conclave/integrationtests/general/common/tasks/CreateSocket.kt
+++ b/integration-tests/general/common/src/main/kotlin/com/r3/conclave/integrationtests/general/common/tasks/CreateSocket.kt
@@ -8,11 +8,10 @@ import java.net.ServerSocket
 
 @Serializable
 class CreateSocket : EnclaveTestAction<Unit>() {
+    
     override fun run(context: EnclaveContext, isMail: Boolean) {
-
         val server = ServerSocket(9999)
         val socket = server.accept()
-
     }
 
     override fun resultSerializer(): KSerializer<Unit> = Unit.serializer()

--- a/integration-tests/general/common/src/main/kotlin/com/r3/conclave/integrationtests/general/common/tasks/EnclaveTestAction.kt
+++ b/integration-tests/general/common/src/main/kotlin/com/r3/conclave/integrationtests/general/common/tasks/EnclaveTestAction.kt
@@ -118,12 +118,15 @@ private val protoBuf = ProtoBuf {
             subclass(SqlQuery::class, SqlQuery.serializer())
             subclass(ExecuteSql::class, ExecuteSql.serializer())
             subclass(RenameFile::class, RenameFile.serializer())
+            subclass(CreateSymlink::class, CreateSymlink.serializer())
+            subclass(CreateHardlink::class, CreateHardlink.serializer())
             subclass(MovePath::class, MovePath.serializer())
             subclass(WalkPath::class, WalkPath.serializer())
             subclass(ReadAndWriteFilesToDefaultFileSystem::class, ReadAndWriteFilesToDefaultFileSystem.serializer())
             subclass(WalkAndDelete::class, WalkAndDelete.serializer())
             subclass(ListFilesNTimes::class, ListFilesNTimes.serializer())
             subclass(CreateAttestationQuoteAction::class, CreateAttestationQuoteAction.serializer())
+            subclass(CreateSocket::class, CreateSocket.serializer())
         }
     }
 }

--- a/integration-tests/general/common/src/main/kotlin/com/r3/conclave/integrationtests/general/common/tasks/FileSystemActions.kt
+++ b/integration-tests/general/common/src/main/kotlin/com/r3/conclave/integrationtests/general/common/tasks/FileSystemActions.kt
@@ -68,20 +68,20 @@ class DeleteFile(private val path: String, private val nioApi: Boolean) : FileSy
 @Serializable
 class CreateSymlink(private val filePath: String, private val symlinkPath: String) : FileSystemAction<Unit>() {
     override fun run(context: EnclaveContext, isMail: Boolean) {
-        val file = File(filePath)
-        val symLink = File(symlinkPath)
-        Files.createSymbolicLink(symLink.toPath(), file.toPath())
+        val file = Paths.get(filePath)
+        val symLink = Paths.get(symlinkPath)
+        Files.createSymbolicLink(symLink, file)
     }
 
     override fun resultSerializer(): KSerializer<Unit> = Unit.serializer()
 }
 
 @Serializable
-class CreateHardlink(private val filePath: String, private val symlinkPath: String) : FileSystemAction<Unit>() {
+class CreateHardlink(private val filePath: String, private val hardlinkPath: String) : FileSystemAction<Unit>() {
     override fun run(context: EnclaveContext, isMail: Boolean) {
-        val file = File(filePath)
-        val symLink = File(symlinkPath)
-        Files.createLink(symLink.toPath(), file.toPath())
+        val file = Paths.get(filePath)
+        val hardLink = Paths.get(hardlinkPath)
+        Files.createLink(hardLink, file)
     }
 
     override fun resultSerializer(): KSerializer<Unit> = Unit.serializer()

--- a/integration-tests/general/common/src/main/kotlin/com/r3/conclave/integrationtests/general/common/tasks/FileSystemActions.kt
+++ b/integration-tests/general/common/src/main/kotlin/com/r3/conclave/integrationtests/general/common/tasks/FileSystemActions.kt
@@ -66,6 +66,27 @@ class DeleteFile(private val path: String, private val nioApi: Boolean) : FileSy
 }
 
 @Serializable
+class CreateSymlink(private val filePath: String, private val symlinkPath: String) : FileSystemAction<Unit>() {
+    override fun run(context: EnclaveContext, isMail: Boolean) {
+        val file = File(filePath)
+        val symLink = File(symlinkPath)
+        Files.createSymbolicLink(symLink.toPath(), file.toPath())
+    }
+
+    override fun resultSerializer(): KSerializer<Unit> = Unit.serializer()
+}
+
+@Serializable
+class CreateHardlink(private val filePath: String, private val symlinkPath: String) : FileSystemAction<Unit>() {
+    override fun run(context: EnclaveContext, isMail: Boolean) {
+        val file = File(filePath)
+        val symLink = File(symlinkPath)
+        Files.createLink(symLink.toPath(), file.toPath())
+    }
+
+    override fun resultSerializer(): KSerializer<Unit> = Unit.serializer()
+}
+@Serializable
 class RenameFile(private val oldPath: String, private val newPath: String) : FileSystemAction<Boolean>() {
     override fun run(context: EnclaveContext, isMail: Boolean): Boolean {
         return File(oldPath).renameTo(File(newPath))

--- a/integration-tests/general/tests/build.gradle
+++ b/integration-tests/general/tests/build.gradle
@@ -17,8 +17,8 @@ dependencies {
     testImplementation project(":general:common-test")
     testRuntimeOnly project(path: ":general:default-enclave", configuration: enclaveMode)
     testRuntimeOnly project(path: ":general:persisting-enclave", configuration: enclaveMode)
-    //testRuntimeOnly project(path: ":general:threadsafe-enclave", configuration: enclaveMode)
-    //testRuntimeOnly project(path: ":general:threadsafe-enclave-same-signer", configuration: enclaveMode)
+    testRuntimeOnly project(path: ":general:threadsafe-enclave", configuration: enclaveMode)
+    testRuntimeOnly project(path: ":general:threadsafe-enclave-same-signer", configuration: enclaveMode)
     testRuntimeOnly project(path: ":general:filesystem-db-enclave", configuration: enclaveMode)
     testRuntimeOnly "org.slf4j:slf4j-simple:$slf4j_version"
     kds "com.r3.conclave:kds-simulation:$kds_version" // Use the simulation KDS for testing

--- a/integration-tests/general/tests/build.gradle
+++ b/integration-tests/general/tests/build.gradle
@@ -17,8 +17,8 @@ dependencies {
     testImplementation project(":general:common-test")
     testRuntimeOnly project(path: ":general:default-enclave", configuration: enclaveMode)
     testRuntimeOnly project(path: ":general:persisting-enclave", configuration: enclaveMode)
-    testRuntimeOnly project(path: ":general:threadsafe-enclave", configuration: enclaveMode)
-    testRuntimeOnly project(path: ":general:threadsafe-enclave-same-signer", configuration: enclaveMode)
+    //testRuntimeOnly project(path: ":general:threadsafe-enclave", configuration: enclaveMode)
+    //testRuntimeOnly project(path: ":general:threadsafe-enclave-same-signer", configuration: enclaveMode)
     testRuntimeOnly project(path: ":general:filesystem-db-enclave", configuration: enclaveMode)
     testRuntimeOnly "org.slf4j:slf4j-simple:$slf4j_version"
     kds "com.r3.conclave:kds-simulation:$kds_version" // Use the simulation KDS for testing

--- a/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/EnclaveHostNativeTest.kt
+++ b/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/EnclaveHostNativeTest.kt
@@ -5,6 +5,7 @@ import com.r3.conclave.integrationtests.general.common.tasks.*
 import com.r3.conclave.integrationtests.general.common.toByteArray
 import com.r3.conclave.integrationtests.general.common.toInt
 import com.r3.conclave.integrationtests.general.commontest.AbstractEnclaveActionTest
+import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.jupiter.api.Test
@@ -82,5 +83,15 @@ class EnclaveHostNativeTest : AbstractEnclaveActionTest() {
         assertThatExceptionOfType(IllegalStateException::class.java).isThrownBy {
             enclaveHost().mockEnclave
         }
+    }
+
+    @Test
+    fun `create socket fails`() {
+        Assertions.setMaxStackTraceElementsDisplayed(1000)
+        Assertions.assertThatThrownBy {
+            callEnclave(CreateSocket())
+        }
+            .isInstanceOf(com.r3.conclave.common.EnclaveException::class.java)
+            .hasCauseExactlyInstanceOf(java.net.SocketException::class.java)
     }
 }

--- a/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/EnclaveHostNativeTest.kt
+++ b/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/EnclaveHostNativeTest.kt
@@ -1,14 +1,14 @@
 package com.r3.conclave.integrationtests.general.tests
 
+import com.r3.conclave.common.EnclaveException
 import com.r3.conclave.host.EnclaveHost
 import com.r3.conclave.integrationtests.general.common.tasks.*
 import com.r3.conclave.integrationtests.general.common.toByteArray
 import com.r3.conclave.integrationtests.general.common.toInt
 import com.r3.conclave.integrationtests.general.commontest.AbstractEnclaveActionTest
-import org.assertj.core.api.Assertions
-import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatExceptionOfType
+import org.assertj.core.api.Assertions.*
 import org.junit.jupiter.api.Test
+import java.net.SocketException
 
 class EnclaveHostNativeTest : AbstractEnclaveActionTest() {
     @Test
@@ -87,10 +87,10 @@ class EnclaveHostNativeTest : AbstractEnclaveActionTest() {
 
     @Test
     fun `create socket fails`() {
-        Assertions.assertThatThrownBy {
+        assertThatThrownBy {
             callEnclave(CreateSocket())
         }
-            .isInstanceOf(com.r3.conclave.common.EnclaveException::class.java)
-            .hasCauseExactlyInstanceOf(java.net.SocketException::class.java)
+            .isInstanceOf(EnclaveException::class.java)
+            .hasCauseExactlyInstanceOf(SocketException::class.java)
     }
 }

--- a/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/EnclaveHostNativeTest.kt
+++ b/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/EnclaveHostNativeTest.kt
@@ -87,7 +87,6 @@ class EnclaveHostNativeTest : AbstractEnclaveActionTest() {
 
     @Test
     fun `create socket fails`() {
-        Assertions.setMaxStackTraceElementsDisplayed(1000)
         Assertions.assertThatThrownBy {
             callEnclave(CreateSocket())
         }

--- a/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/filesystem/FileSystemEnclaveTest.kt
+++ b/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/filesystem/FileSystemEnclaveTest.kt
@@ -164,7 +164,7 @@ abstract class FileSystemEnclaveTest(defaultEnclaveClassName: String) :
             callEnclave(CreateSymlink(symlinkPath, filePath))
         }
             .isInstanceOf(RuntimeException::class.java)
-            .hasCauseExactlyInstanceOf(java.nio.file.FileSystemException::class.java)
+            .hasCauseExactlyInstanceOf(FileSystemException::class.java)
     }
 
     fun createHardlink(symlinkPath: String, filePath: String) {
@@ -172,6 +172,6 @@ abstract class FileSystemEnclaveTest(defaultEnclaveClassName: String) :
             callEnclave(CreateSymlink(symlinkPath, filePath))
         }
             .isInstanceOf(RuntimeException::class.java)
-            .hasCauseExactlyInstanceOf(java.nio.file.FileSystemException::class.java)
+            .hasCauseExactlyInstanceOf(FileSystemException::class.java)
     }
 }

--- a/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/filesystem/FileSystemEnclaveTest.kt
+++ b/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/filesystem/FileSystemEnclaveTest.kt
@@ -7,7 +7,9 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import java.io.IOException
 import java.nio.file.DirectoryNotEmptyException
 import java.nio.file.NoSuchFileException
+import java.nio.file.FileSystemException
 import java.util.concurrent.atomic.AtomicInteger
+
 
 // TODO The file system tests should test for both persisting and in-memory scenerios.
 abstract class FileSystemEnclaveTest(defaultEnclaveClassName: String) :

--- a/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/filesystem/FileSystemEnclaveTest.kt
+++ b/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/filesystem/FileSystemEnclaveTest.kt
@@ -15,7 +15,8 @@ abstract class FileSystemEnclaveTest(defaultEnclaveClassName: String) :
     constructor() : this(FILESYSTEM_ENCLAVE_CLASS_NAME)
 
     companion object {
-        const val FILESYSTEM_ENCLAVE_CLASS_NAME = "com.r3.conclave.integrationtests.general.persistingenclave.PersistingEnclave"
+        const val FILESYSTEM_ENCLAVE_CLASS_NAME =
+            "com.r3.conclave.integrationtests.general.persistingenclave.PersistingEnclave"
     }
 
     val uid = AtomicInteger()
@@ -156,5 +157,21 @@ abstract class FileSystemEnclaveTest(defaultEnclaveClassName: String) :
             .isInstanceOf(RuntimeException::class.java)
             .hasCauseExactlyInstanceOf(exception)
             .cause.hasMessageContaining(path)
+    }
+
+    fun createSymlink(symlinkPath: String, filePath: String) {
+        assertThatThrownBy {
+            callEnclave(CreateSymlink(symlinkPath, filePath))
+        }
+            .isInstanceOf(RuntimeException::class.java)
+            .hasCauseExactlyInstanceOf(java.nio.file.FileSystemException::class.java)
+    }
+
+    fun createHardlink(symlinkPath: String, filePath: String) {
+        assertThatThrownBy {
+            callEnclave(CreateSymlink(symlinkPath, filePath))
+        }
+            .isInstanceOf(RuntimeException::class.java)
+            .hasCauseExactlyInstanceOf(java.nio.file.FileSystemException::class.java)
     }
 }

--- a/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/filesystem/PathsTest.kt
+++ b/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/filesystem/PathsTest.kt
@@ -20,4 +20,27 @@ class PathsTest : FileSystemEnclaveTest() {
         callEnclave(PathsGet(path))
         deleteFile(path, nioApi)
     }
+    @ParameterizedTest
+    @CsvSource(
+        "/paths.data, /paths.datalink",
+        "/tmp/paths.data, /tmp/paths.datalink"
+    )
+    fun symlink(path: String, symlinkPath: String) {
+        val fileData = byteArrayOf(1, 2, 3)
+        filesWrite(path, fileData)
+
+        createSymlink(symlinkPath, path)
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        "/paths.data, /paths.datalink",
+        "/tmp/paths.data, /tmp/paths.datalink"
+    )
+    fun link(path: String, symlinkPath: String) {
+        val fileData = byteArrayOf(1, 2, 3)
+        filesWrite(path, fileData)
+
+        createHardlink(symlinkPath, path)
+    }
 }

--- a/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/filesystem/PathsTest.kt
+++ b/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/filesystem/PathsTest.kt
@@ -23,7 +23,10 @@ class PathsTest : FileSystemEnclaveTest() {
     @ParameterizedTest
     @CsvSource(
         "/paths.data, /paths.datalink",
-        "/tmp/paths.data, /tmp/paths.datalink"
+        "/tmp/paths.data, /tmp/paths.datalink",
+        "/paths.data, /tmp/paths.datalink",
+        "/tmp/paths.data, /paths.datalink"
+
     )
     fun symlink(path: String, symlinkPath: String) {
         val fileData = byteArrayOf(1, 2, 3)
@@ -35,7 +38,9 @@ class PathsTest : FileSystemEnclaveTest() {
     @ParameterizedTest
     @CsvSource(
         "/paths.data, /paths.datalink",
-        "/tmp/paths.data, /tmp/paths.datalink"
+        "/tmp/paths.data, /tmp/paths.datalink",
+        "/paths.data, /tmp/paths.datalink",
+        "/tmp/paths.data, /paths.datalink"
     )
     fun link(path: String, symlinkPath: String) {
         val fileData = byteArrayOf(1, 2, 3)


### PR DESCRIPTION
Many Linux Posix functions were previously stubbed in such a way that the enclave would abort when these were called.
We now want to return an error instead, so that it is up to the JVM (whose bytecode gets compiled with Native Image) interacting with the Posix calls to handle errors.

This PR also adds tests for the symbolic and hard link (https://r3-cev.atlassian.net/browse/CON-861, https://r3-cev.atlassian.net/browse/CON-862) 

