### PR TITLE
CON-1193 - conclave init - Added a logging framework to be used as default by the projects generated using the conclave-init tool

### DIFF
--- a/conclave-init/template/host/build.gradle
+++ b/conclave-init/template/host/build.gradle
@@ -1,11 +1,7 @@
 plugins {
-    id 'application'
-    id 'org.springframework.boot' version '2.6.1'
-}
-
-// Use the provided main method for the web host.
-application {
-    mainClass.set("com.r3.conclave.host.web.EnclaveWebHost")
+    id 'java'
+    id 'org.springframework.boot' version '2.7.4'
+    id "io.spring.dependency-management" version "1.0.11.RELEASE"
 }
 
 // Define a Gradle flag "enclaveMode" which controls which enclave mode to use when building the host. The default is
@@ -19,11 +15,16 @@ tasks.register("prepareForSigning") {
 }
 
 dependencies {
+    // Change this to your preferred logging framework
+    runtimeOnly 'ch.qos.logback:logback-classic'
     runtimeOnly project(path: ":enclave", configuration: mode)
     runtimeOnly "com.r3.conclave:conclave-web-host:$conclaveVersion"
 }
 
 bootJar {
+    // Use the provided main method for the web host.
+    mainClass.set("com.r3.conclave.host.web.EnclaveWebHost")
+
     // Include the enclave mode in the filename for clarity.
     archiveClassifier.set(mode)
 }

--- a/conclave-init/template/host/build.gradle
+++ b/conclave-init/template/host/build.gradle
@@ -24,7 +24,9 @@ dependencies {
 springBoot {
     // Use the provided main method for the web host.
     mainClass.set("com.r3.conclave.host.web.EnclaveWebHost")
+}
 
+bootJar {
     // Include the enclave mode in the filename for clarity.
     archiveClassifier.set(mode)
 }

--- a/conclave-init/template/host/build.gradle
+++ b/conclave-init/template/host/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     runtimeOnly "com.r3.conclave:conclave-web-host:$conclaveVersion"
 }
 
-bootJar {
+springBoot {
     // Use the provided main method for the web host.
     mainClass.set("com.r3.conclave.host.web.EnclaveWebHost")
 

--- a/conclave-init/template/host/build.gradle
+++ b/conclave-init/template/host/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'org.springframework.boot' version '2.7.4'
-    id "io.spring.dependency-management" version "1.0.11.RELEASE"
+    id "io.spring.dependency-management" version "1.1.0"
 }
 
 // Define a Gradle flag "enclaveMode" which controls which enclave mode to use when building the host. The default is

--- a/docs/docs/conclave-web-host.md
+++ b/docs/docs/conclave-web-host.md
@@ -21,7 +21,7 @@ java -jar host.jar [options]
 
 !!!note
     If executing your project using Gradle, then arguments can be passed using the --args option. For example:
-    `./gradlew :host:run --args="--sealed-state-file=<path>"`
+    `./gradlew :host:bootRun --args="--sealed-state-file=<path>"`
 
 ### `--sealed.state.file=<path>`
 Path at which the enclave should store the sealed state containing the persistent map, if the persistent map is 

--- a/docs/docs/mockmode.md
+++ b/docs/docs/mockmode.md
@@ -11,7 +11,7 @@ and host are all just regular function calls. You can expect very short build ti
 and enjoy the regular Java development experience.
 
 !!!tip
-    To debug your host application in mock mode from IntelliJ, find the `:host:run` task in the gradle menu, add the `-PenclaveMode=mock` argument to the run configuration, and then run the task in debug mode.
+    To debug your host application in mock mode from IntelliJ, find the `:host:bootRun` task in the gradle menu, add the `-PenclaveMode=mock` argument to the run configuration, and then run the task in debug mode.
 
 ## Using mock mode
 

--- a/docs/docs/writing-your-own-enclave-host.md
+++ b/docs/docs/writing-your-own-enclave-host.md
@@ -66,7 +66,7 @@ dependencies {
 ```
 7. Check that the host and client run without any issues:
 ```bash
-./gradlew :host:run
+./gradlew :host:bootRun
 ./gradlew :client:run
 ```
 

--- a/test-conclave-init.sh
+++ b/test-conclave-init.sh
@@ -39,7 +39,7 @@ sed -i "s/repositories {/repositories {\nmaven { url = '..\/repo' }/" settings.g
 echo Run Java project host and client
 
 # NOTE: this command is only run in mock mode, so that the signer can be provided below.
-./gradlew :host:run & _PID=$!
+./gradlew :host:bootRun & _PID=$!
 sleep 5
 ./gradlew :client:run \
   --args="'S:0000000000000000000000000000000000000000000000000000000000000000 PROD:1 SEC:INSECURE'"
@@ -73,7 +73,7 @@ sed -i "s/repositories {/repositories {\nmaven { url = '..\/repo' }/" settings.g
 echo Run Kotlin project host and client
 
 # NOTE: this command is only run in mock mode, so that the signer can be provided below.
-./gradlew :host:run & _PID=$!
+./gradlew :host:bootRun & _PID=$!
 sleep 5
 ./gradlew :client:run \
   --args="'S:0000000000000000000000000000000000000000000000000000000000000000 PROD:1 SEC:INSECURE'"

--- a/test-conclave-init.sh
+++ b/test-conclave-init.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eou pipefail
+set -eoux pipefail
 
 # This script requires a local build of the SDK at build/repo, which can be produced by running
 # ./gradlew publishAllPublicationsToBuildRepository.
@@ -40,7 +40,7 @@ echo Run Java project host and client
 
 # NOTE: this command is only run in mock mode, so that the signer can be provided below.
 host_output_file="host_output.log"
-./gradlew :host:bootRun & > $host_output_file
+./gradlew :host:bootRun > $host_output_file &
 _PID=$!
 
 sleep 5

--- a/versions.gradle
+++ b/versions.gradle
@@ -18,7 +18,7 @@ ext {
     guava_version = '31.1-jre'
     mockito_version = '4.8.0'
     spring_boot_version = '2.7.4'
-    spring_dependency_management_version = '1.0.11.RELEASE'
+    spring_dependency_management_version = '1.1.0'
     javax_json_version = '1.1.4'
     ibm_icu4j_version = '71.1'
     locationtech_jts_version = '1.16.0'


### PR DESCRIPTION
The projects generated by `conclave-init` will now have a default logging framework. 
Updated io.spring.dependency-management to the latest version (1.1.0).
Added a check to ensure the host generates logs by default.