### PR TITLE
[CON-1198] Gramine integration tests fail to locate built enclaves

### DIFF
--- a/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/GradleEnclavePlugin.kt
+++ b/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/GradleEnclavePlugin.kt
@@ -184,6 +184,7 @@ class GradleEnclavePlugin @Inject constructor(private val layout: ProjectLayout)
             val location = enclaveClassNameTask.outputEnclaveClassName.get().replace('.', '/') + "-${typeLowerCase}"
             val jarTask = task as Jar
             jarTask.into(location)
+            // TODO: Figure out how to avoid this rename
             jarTask.rename(shadowJarTask.archiveFile.get().asFile.name, "enclave-shadow.jar")
         }
     }


### PR DESCRIPTION
# Changes
- Add line to rename the jar output in `IntoGramineTask` so that it is always `enclave-shadow.jar`.

# Notes
The problem is caused by the shadow plugin, which will sometimes insert the sdk version string into the fat jar name resulting in a jar called `enclave-<sdk-version>-shadow.jar` rather than `enclave-shadow.jar`. The scanning code in the host then fails to find the jar file (because it's looking for the wrong one). This PR just adds a line to rename the shadow jar when creating the gramine enclave jar.