### PR TITLE
CON-523: Fix Dokka API documentation on docs site

### DIFF
--- a/conclave-client/src/main/kotlin/com/r3/conclave/client/EnclaveClient.kt
+++ b/conclave-client/src/main/kotlin/com/r3/conclave/client/EnclaveClient.kt
@@ -25,7 +25,8 @@ import java.util.concurrent.ScheduledExecutorService
  * Creating a new client instance requires providing an [EnclaveConstraint] object. This acts as an identity of the
  * enclave and is used to check that the client is communicating with the intended one. A private encryption key is also
  * required. There is an constructor overload which creates a random new one for you, or you can use
- * [Curve25519PrivateKey.random] to create a new random one yourself.
+ * [Curve25519PrivateKey.random](https://docs.conclave.net/api/-conclave%20-core/com.r3.conclave.mail/-curve25519-private-key/random.html)
+ * to create a new random one yourself.
  *
  * After creating a new client, users will need to call [start] and provide an [EnclaveTransport] for communicating with
  * the host. Which implemenation of [EnclaveTransport] is used will depend on the network transport between the client

--- a/conclave-common/src/main/kotlin/com/r3/conclave/common/EnclaveInstanceInfo.kt
+++ b/conclave-common/src/main/kotlin/com/r3/conclave/common/EnclaveInstanceInfo.kt
@@ -61,13 +61,13 @@ interface EnclaveInstanceInfo {
      * Returns a new [PostOffice] instance for encrypting mail to this target enclave on the given topic.
      *
      * Each mail created by this post office will be authenticated with the given private key, and will act as the client's
-     * authenticated identity to the enclave (see [EnclaveMail.authenticatedSender]). Typically only one sender key is
-     * required per client (a new one can be created using [Curve25519PrivateKey.random]).
+     * authenticated identity to the enclave (see [EnclaveMail.getAuthenticatedSender](https://docs.conclave.net/api/-conclave%20-core/com.r3.conclave.mail/-enclave-mail/get-authenticated-sender.html)).
+     * Typically only one sender key is required per client (a new one can be created using [Curve25519PrivateKey.random](https://docs.conclave.net/api/-conclave%20-core/com.r3.conclave.mail/-curve25519-private-key/random.html)).
      *
      * It's very important that related mail are created from the same post office instance, i.e. having the same topic and
      * sender key. This is so the post office can apply an increasing sequence number to each mail, which the target
      * enclave will use to make sure they are received in order and that none have been dropped (see
-     * [EnclaveMailHeader.sequenceNumber]).
+     * [EnclaveMailHeader.getSequenceNumber](https://docs.conclave.net/api/-conclave%20-core/com.r3.conclave.mail/-enclave-mail-header/get-sequence-number.html)).
      *
      * For a different stream of mail create another post office with a different topic.
      */
@@ -78,12 +78,13 @@ interface EnclaveInstanceInfo {
      *
      * A new sender private key will be used (which can be retrieved with [PostOffice.senderPrivateKey]), and each mail
      * created by this post office will be authenticated with it and act as the client's authenticated identity to the
-     * enclave (see [EnclaveMail.authenticatedSender]). Typically only one sender key is required per client.
+     * enclave (see [EnclaveMail.getAuthenticatedSender](https://docs.conclave.net/api/-conclave%20-core/com.r3.conclave.mail/-enclave-mail/get-authenticated-sender.html)).
+     * Typically only one sender key is required per client.
      *
      * It's very important that related mail are created from the same post office instance, i.e. having the same topic and
      * sender key. This is so the post office can apply an increasing sequence number to each mail, which the target
      * enclave will use to make sure they are received in order and that none have been dropped (see
-     * [EnclaveMailHeader.sequenceNumber]).
+     * [EnclaveMailHeader.getSequenceNumber](https://docs.conclave.net/api/-conclave%20-core/com.r3.conclave.mail/-enclave-mail-header/get-sequence-number.html)).
      *
      * For a different stream of mail create another post office with a different topic.
      */

--- a/conclave-enclave/src/main/kotlin/com/r3/conclave/enclave/Enclave.kt
+++ b/conclave-enclave/src/main/kotlin/com/r3/conclave/enclave/Enclave.kt
@@ -1068,7 +1068,7 @@ Received: $attestationReportBody"""
 
     /**
      * Invoked when a mail has been delivered by the host (via [com.r3.conclave.host.EnclaveHost.deliverMail]),
-     * successfully decrypted and authenticated (so the [EnclaveMail.authenticatedSender] property is reliable).
+     * successfully decrypted and authenticated (so the [EnclaveMail.getAuthenticatedSender](https://docs.conclave.net/api/-conclave%20-core/com.r3.conclave.mail/-enclave-mail/get-authenticated-sender.html) property is reliable).
      *
      * Default implementation throws [UnsupportedOperationException] so you should not
      * perform a supercall.

--- a/conclave-mail/src/main/kotlin/com/r3/conclave/mail/PostOffice.kt
+++ b/conclave-mail/src/main/kotlin/com/r3/conclave/mail/PostOffice.kt
@@ -160,7 +160,7 @@ abstract class PostOffice(
          * Create a new post office instance for encrypting mail to the given recipient. Each mail will be authenticated
          * with the given private key and will have the given topic.
          *
-         * A new random sender key can be created using [Curve25519PrivateKey.random](https://docs.conclave.net/api/-conclave%20-core/com.r3.conclave.mail/-curve25519-private-key/random.html)).
+         * A new random sender key can be created using [Curve25519PrivateKey.random](https://docs.conclave.net/api/-conclave%20-core/com.r3.conclave.mail/-curve25519-private-key/random.html).
          *
          * Do not use this for mail targeted at an enclave. Instead use [com.r3.conclave.common.EnclaveInstanceInfo.createPostOffice], or if
          * inside an enclave, [com.r3.conclave.enclave.Enclave.postOffice].

--- a/conclave-mail/src/main/kotlin/com/r3/conclave/mail/PostOffice.kt
+++ b/conclave-mail/src/main/kotlin/com/r3/conclave/mail/PostOffice.kt
@@ -139,7 +139,7 @@ interface EnclaveMail : EnclaveMailHeader {
  */
 abstract class PostOffice(
     /**
-     * The sender private key used to authenticate mail and create the [EnclaveMail.getAuthenticatedSender](https://docs.conclave.net/api/-conclave%20-core/com.r3.conclave.mail/-enclave-mail/get-authenticated-sender.html))
+     * The sender private key used to authenticate mail and create the [EnclaveMail.getAuthenticatedSender](https://docs.conclave.net/api/-conclave%20-core/com.r3.conclave.mail/-enclave-mail/get-authenticated-sender.html)
      * field.
      *
      * @see [EnclaveMail.getAuthenticatedSender](https://docs.conclave.net/api/-conclave%20-core/com.r3.conclave.mail/-enclave-mail/get-authenticated-sender.html)

--- a/conclave-mail/src/main/kotlin/com/r3/conclave/mail/PostOffice.kt
+++ b/conclave-mail/src/main/kotlin/com/r3/conclave/mail/PostOffice.kt
@@ -100,12 +100,12 @@ interface EnclaveMail : EnclaveMailHeader {
  * A post office is an object for creating a stream of related mail encrypted to a [destinationPublicKey].
  *
  * Related mail form an ordered list on the same [topic]. This ordering is defined by the sequence number field in each
- * mail header (see [EnclaveMailHeader.sequenceNumber]) and it's important the ordering is preserved for the receiving
- * enclave.
+ * mail header (see [EnclaveMailHeader.getSequenceNumber](https://docs.conclave.net/api/-conclave%20-core/com.r3.conclave.mail/-enclave-mail-header/get-sequence-number.html))
+ * and it's important the ordering is preserved for the receiving enclave.
  *
  * A post office also requires a [senderPrivateKey], which is used to authenticate each mail and is received by the
- * recipient as an authenticated public key (see [EnclaveMail.authenticatedSender]). This can be used by the recipient
- * for user authentication but is also required if they want to reply back.
+ * recipient as an authenticated public key (see [EnclaveMail.getAuthenticatedSender](https://docs.conclave.net/api/-conclave%20-core/com.r3.conclave.mail/-enclave-mail/get-authenticated-sender.html)).
+ * This can be used by the recipient for user authentication but is also required if they want to reply back.
  *
  * The sender key can either be a short-term eptherimal key which is used only once and then discarded (e.g. when the client
  * process exits) or it can be a long-term identity key. If the later then it's important to keep track of the current
@@ -139,9 +139,10 @@ interface EnclaveMail : EnclaveMailHeader {
  */
 abstract class PostOffice(
     /**
-     * The sender private key used to authenticate mail and create the [EnclaveMail.authenticatedSender] field.
+     * The sender private key used to authenticate mail and create the [EnclaveMail.getAuthenticatedSender](https://docs.conclave.net/api/-conclave%20-core/com.r3.conclave.mail/-enclave-mail/get-authenticated-sender.html))
+     * field.
      *
-     * @see [EnclaveMail.authenticatedSender]
+     * @see [EnclaveMail.getAuthenticatedSender](https://docs.conclave.net/api/-conclave%20-core/com.r3.conclave.mail/-enclave-mail/get-authenticated-sender.html)
      */
     public final override val senderPrivateKey: PrivateKey,
     /**
@@ -159,7 +160,7 @@ abstract class PostOffice(
          * Create a new post office instance for encrypting mail to the given recipient. Each mail will be authenticated
          * with the given private key and will have the given topic.
          *
-         * A new random sender key can be created using [Curve25519PrivateKey.random].
+         * A new random sender key can be created using [Curve25519PrivateKey.random](https://docs.conclave.net/api/-conclave%20-core/com.r3.conclave.mail/-curve25519-private-key/random.html)).
          *
          * Do not use this for mail targeted at an enclave. Instead use [com.r3.conclave.common.EnclaveInstanceInfo.createPostOffice], or if
          * inside an enclave, [com.r3.conclave.enclave.Enclave.postOffice].
@@ -286,7 +287,8 @@ abstract class PostOffice(
 
     /**
      * Decodes and decrypts the mail with [senderPrivateKey] and verifies that the authenticated sender
-     * ([EnclaveMail.authenticatedSender]) matches the [destinationPublicKey].
+     * ([EnclaveMail.getAuthenticatedSender](https://docs.conclave.net/api/-conclave%20-core/com.r3.conclave.mail/-enclave-mail/get-authenticated-sender.html))
+     * matches the [destinationPublicKey].
      *
      * @param encryptedEnclaveMail The encrypted mail bytes, produced by the sender's [encryptMail].
      *

--- a/docs/docs/mail.md
+++ b/docs/docs/mail.md
@@ -39,7 +39,7 @@ Conclave Mail is [Curve25519](https://en.wikipedia.org/wiki/Curve25519).
 
 The client knows the target's public key either because the enclave puts its public key into the remote attestation, 
 represented by an [`EnclaveInstanceInfo`](api/-conclave%20-core/com.r3.conclave.common/-enclave-instance-info/index.html)
-object, or because the enclave obtained the key from an earlier Mail message. Two public keys are all that both 
+object, or because the client obtained the key from an earlier Mail message. Two public keys are all that both 
 parties need to compute the same AES key without any man-in-the-middle being able to calculate the same value.
 
 The sender may also have a long-term static public key that the target will recognize. Conclave appends an 


### PR DESCRIPTION
This is to update the docs site by matching the changes in the [other PR](https://github.com/R3Conclave/conclave-core-sdk/pull/89). Merging to release/1.3 branch.