### PR TITLE
CON-1187: Fix QA tests by changing the name of "enclave-bundle" jars

### DIFF
--- a/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/GradleEnclavePlugin.kt
+++ b/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/GradleEnclavePlugin.kt
@@ -506,7 +506,7 @@ class GradleEnclavePlugin @Inject constructor(private val layout: ProjectLayout)
             val enclaveBundleJarTask = target.createTask<Jar>("enclaveBundle${type}Jar") { task ->
                 task.group = CONCLAVE_GROUP
                 task.description = "Compile an ${type}-mode enclave that can be loaded by SGX."
-                task.archiveAppendix.set("enclave-bundle")
+                task.archiveAppendix.set("-bundle")
                 task.archiveClassifier.set(typeLowerCase)
 
                 val bundleOutput: Provider<RegularFile> = runtimeType.flatMap {

--- a/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/GradleEnclavePlugin.kt
+++ b/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/GradleEnclavePlugin.kt
@@ -506,7 +506,7 @@ class GradleEnclavePlugin @Inject constructor(private val layout: ProjectLayout)
             val enclaveBundleJarTask = target.createTask<Jar>("enclaveBundle${type}Jar") { task ->
                 task.group = CONCLAVE_GROUP
                 task.description = "Compile an ${type}-mode enclave that can be loaded by SGX."
-                task.archiveAppendix.set("-bundle")
+                task.archiveAppendix.set("bundle")
                 task.archiveClassifier.set(typeLowerCase)
 
                 val bundleOutput: Provider<RegularFile> = runtimeType.flatMap {

--- a/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/GradleEnclavePlugin.kt
+++ b/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/GradleEnclavePlugin.kt
@@ -506,8 +506,8 @@ class GradleEnclavePlugin @Inject constructor(private val layout: ProjectLayout)
             val enclaveBundleJarTask = target.createTask<Jar>("enclaveBundle${type}Jar") { task ->
                 task.group = CONCLAVE_GROUP
                 task.description = "Compile an ${type}-mode enclave that can be loaded by SGX."
-                task.archiveBaseName.set("enclave-bundle")
-                task.archiveAppendix.set(typeLowerCase)
+                task.archiveAppendix.set("enclave-bundle")
+                task.archiveClassifier.set(typeLowerCase)
 
                 val bundleOutput: Provider<RegularFile> = runtimeType.flatMap {
                     when (it) {


### PR DESCRIPTION
QA tests are currently failing because this is where we use a different technique to deploy our host applications.
In QA we generate call `distZip`, `distTar` tasks in order to bundle the host, upload it to the CRAFT VMs and unzip it.
We have a bug when the host had multiple enclaves: we use the same name for different "enclave bundle" jars. Even though these jars are actually present in differently named directories, when we call `distZip` we actually take them out of the "directory structure" context and therefore they are conflicting.
This causes issues in QA: Gradle complains about a missing strategy to handle this. 
Changing the name as we do in this PR should solve this problem