### PR TITLE
CON-1262: Make sure EnclaveHost.close() cannot be called inside a callback

### DIFF
--- a/conclave-enclave/src/main/kotlin/com/r3/conclave/enclave/Enclave.kt
+++ b/conclave-enclave/src/main/kotlin/com/r3/conclave/enclave/Enclave.kt
@@ -582,6 +582,7 @@ abstract class Enclave {
      */
     private inner class StopCallHandler : CallHandler {
         override fun handleCall(parameterBuffer: ByteBuffer): ByteBuffer? {
+            check(!lock.isHeldByCurrentThread) { "Enclave cannot be shutdown in a callback" }
             lock.withLock {
                 enclaveStateManager.transitionStateFrom<Started>(to = Closed)
                 // Wait until all receive calls being processed have completed

--- a/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/DefaultEnclaveTests.kt
+++ b/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/DefaultEnclaveTests.kt
@@ -2,13 +2,10 @@ package com.r3.conclave.integrationtests.general.tests
 
 import com.r3.conclave.integrationtests.general.common.tasks.CheckNotMultiThreadedAction
 import com.r3.conclave.integrationtests.general.common.tasks.Echo
-import com.r3.conclave.integrationtests.general.common.tasks.EchoWithCallback
 import com.r3.conclave.integrationtests.general.common.tasks.PutPersistentMap
 import com.r3.conclave.integrationtests.general.common.threadWithFuture
 import com.r3.conclave.integrationtests.general.commontest.AbstractEnclaveActionTest
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import kotlin.random.Random
@@ -58,20 +55,6 @@ class DefaultEnclaveTests : AbstractEnclaveActionTest() {
         for (n in 1..1000) {
             callEnclave(echo)
         }
-    }
-
-    @Test
-    fun `destroy in OCALL`() {
-        val echo = EchoWithCallback(byteArrayOf())
-        var called = false
-        assertThatThrownBy {
-            callEnclave(echo) {
-                called = true
-                enclaveHost().close()
-                null
-            }
-        }
-        assertTrue(called, "Ocall must be called")
     }
 
     @Test

--- a/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/EnclaveHostTest.kt
+++ b/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/EnclaveHostTest.kt
@@ -78,12 +78,12 @@ class EnclaveHostTest : AbstractEnclaveActionTest() {
     fun `close() in callback not allowed`(@Values(booleans = [false, true]) threadSafeEnclave: Boolean) {
         val echo = EchoWithCallback(byteArrayOf())
         val enclaveHost = enclaveHost(if (threadSafeEnclave) THREAD_SAFE_ENCLAVE else NON_THREAD_SAFE_ENCLAVE)
-        assertThatIllegalStateException().isThrownBy {
+        assertThatThrownBy {
             callEnclave(enclaveHost, echo) {
                 enclaveHost.close()
                 null
             }
-        }.withMessage("Enclave cannot be shutdown in a callback")
+        }.hasMessageContaining("Enclave cannot be shutdown in a callback")
     }
 
     @Test

--- a/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/EnclavePersistentMapTest.kt
+++ b/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/EnclavePersistentMapTest.kt
@@ -12,7 +12,7 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executors
 import kotlin.random.Random
 
-class EnclavePersistentMapTest : AbstractEnclaveActionTest("com.r3.conclave.integrationtests.general.persistingenclave.PersistingEnclave") {
+class EnclavePersistentMapTest : AbstractEnclaveActionTest(PERSISTING_ENCLAVE) {
     @CartesianTest
     fun `persistent map updated by several threads, with enclave restarts`(
         @Enum type: CallType,

--- a/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/SealingTest.kt
+++ b/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/SealingTest.kt
@@ -12,7 +12,7 @@ import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
-class SealingTest : AbstractEnclaveActionTest("com.r3.conclave.integrationtests.general.threadsafeenclave.ThreadSafeEnclave") {
+class SealingTest : AbstractEnclaveActionTest(THREAD_SAFE_ENCLAVE) {
     @ParameterizedTest
     @ValueSource(booleans = [ false, true ])
     fun `seal and unseal with same enclave instance`(withAD: Boolean) {
@@ -37,7 +37,7 @@ class SealingTest : AbstractEnclaveActionTest("com.r3.conclave.integrationtests.
     @ParameterizedTest
     @ValueSource(booleans = [ false, true ])
     fun `unseal with different enclave of same MRSIGNER`(withAD: Boolean) {
-        val sameMrsignerEnclave = enclaveHost("com.r3.conclave.integrationtests.general.threadsafeenclave.ThreadSafeEnclaveSameSigner")
+        val sameMrsignerEnclave = enclaveHost(THREAD_SAFE_ENCLAVE_SAME_SIGNER)
         assertThat(enclaveHost().mrsigner).isEqualTo(sameMrsignerEnclave.mrsigner)
 
         val data = PlaintextAndAD("Sealing Hello World!".toByteArray(), if (withAD) "with AD!".toByteArray() else null)
@@ -49,7 +49,7 @@ class SealingTest : AbstractEnclaveActionTest("com.r3.conclave.integrationtests.
     @ParameterizedTest
     @ValueSource(booleans = [ false, true ])
     fun `unseal with enclave of different MRSIGNER`(withAD: Boolean) {
-        val differentMrsignerEnclave = enclaveHost("com.r3.conclave.integrationtests.general.defaultenclave.DefaultEnclave")
+        val differentMrsignerEnclave = enclaveHost(DEFAULT_ENCLAVE)
         assertThat(enclaveHost().mrsigner).isNotEqualTo(differentMrsignerEnclave.mrsigner)
 
         val data = PlaintextAndAD("Sealing Hello World!".toByteArray(), if (withAD) "with AD!".toByteArray() else null)

--- a/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/ThreadSafeEnclaveTests.kt
+++ b/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/ThreadSafeEnclaveTests.kt
@@ -16,7 +16,7 @@ import java.util.stream.IntStream
 import kotlin.concurrent.withLock
 import kotlin.streams.toList
 
-class ThreadSafeEnclaveTests : AbstractEnclaveActionTest("com.r3.conclave.integrationtests.general.threadsafeenclave.ThreadSafeEnclave") {
+class ThreadSafeEnclaveTests : AbstractEnclaveActionTest(THREAD_SAFE_ENCLAVE) {
     @Test
     fun `concurrent calls into the enclave`() {
         val n = 1000

--- a/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/filesystem/FileSystemEnclaveTest.kt
+++ b/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/filesystem/FileSystemEnclaveTest.kt
@@ -6,20 +6,14 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import java.io.IOException
 import java.nio.file.DirectoryNotEmptyException
-import java.nio.file.NoSuchFileException
 import java.nio.file.FileSystemException
+import java.nio.file.NoSuchFileException
 import java.util.concurrent.atomic.AtomicInteger
 
-
 // TODO The file system tests should test for both persisting and in-memory scenerios.
-abstract class FileSystemEnclaveTest(defaultEnclaveClassName: String) :
-    AbstractEnclaveActionTest(defaultEnclaveClassName) {
-    constructor() : this(FILESYSTEM_ENCLAVE_CLASS_NAME)
-
-    companion object {
-        const val FILESYSTEM_ENCLAVE_CLASS_NAME =
-            "com.r3.conclave.integrationtests.general.persistingenclave.PersistingEnclave"
-    }
+abstract class FileSystemEnclaveTest(defaultEnclaveUnderTest: String) :
+    AbstractEnclaveActionTest(defaultEnclaveUnderTest) {
+    constructor() : this(PERSISTING_ENCLAVE)
 
     val uid = AtomicInteger()
 

--- a/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/filesystem/FilesTest.kt
+++ b/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/filesystem/FilesTest.kt
@@ -224,7 +224,7 @@ class FilesTest : FileSystemEnclaveTest() {
         val corruptedEnclaveResource =
             this::class.java.getResource("/com.r3.conclave.integrationtests.general.tests/corrupted_enclave_disk.gz")
         GZIPInputStream(Path.of(corruptedEnclaveResource!!.toURI()).inputStream()).use { input ->
-            val enclaveFileSystemFile = getFileSystemFilePath(FILESYSTEM_ENCLAVE_CLASS_NAME)
+            val enclaveFileSystemFile = getFileSystemFilePath(PERSISTING_ENCLAVE)
             Files.copy(input, enclaveFileSystemFile!!)
         }
     }

--- a/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/filesystem/db/DatabaseEnclaveTest.kt
+++ b/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/filesystem/db/DatabaseEnclaveTest.kt
@@ -7,7 +7,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 
-class DatabaseEnclaveTest : FileSystemEnclaveTest("com.r3.conclave.integrationtests.filesystem.db.enclave.DatabaseEnclave") {
+class DatabaseEnclaveTest : FileSystemEnclaveTest(DATABASE_ENCLAVE) {
     @ParameterizedTest
     @CsvSource(
         "false, false",


### PR DESCRIPTION
We had an integration test that tested this behaviour, but this is clearly incorrect. The state of the enclave if `close()` is called in the callback after it returns back into the enclave is undefined and probably not usable.