### PR TITLE
[CON-360] exception is thrown if too many threads are requested

### DIFF
--- a/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/ThreadSafeEnclaveTests.kt
+++ b/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/ThreadSafeEnclaveTests.kt
@@ -94,8 +94,6 @@ class ThreadSafeEnclaveTests : AbstractEnclaveActionTest("com.r3.conclave.integr
         assertThat(result).isEqualTo((n * (n + 1)) / 2)
     }
 
-    @Disabled(": CON-360")
-    // fatal error 'PosixJavaThreads.start0: pthread_create'
     @Test
     fun `exception is thrown if too many threads are requested`() {
         val n = 15 // > defaultTCSNum(10)


### PR DESCRIPTION
Changes:
- Re-enable disabled integration test.
- Remove unneeded error message from pthread patch.
- Bump graalvm version to 1.4-SNAPSHOT