### PR TITLE
CON-1223 - Updated the default values of maxThreads and the enclave_worker_threads.

### DIFF
--- a/docs/docs/api-changes.md
+++ b/docs/docs/api-changes.md
@@ -7,6 +7,10 @@
 For security reasons, a client that sets the security level in the [`EnclaveConstraint`](api/-conclave%20-core/com.r3.conclave.common/-enclave-constraint/index.html) to `INSECURE` will no longer be able to connect to `STALE` or `SECURE` enclaves.
 The behavior of the security levels `STALE`, and `SECURE` has not changed.
 
+The default value for the Conclave configuration field `maxThreads` has been increased to 100. This value should be suitable
+to cover most of the use-cases when the logic inside the enclaves uses a large number of threads. There should be no
+considerable performance impact.
+
 ## 1.2 to 1.3
 
 ### Maven Central

--- a/docs/docs/api-changes.md
+++ b/docs/docs/api-changes.md
@@ -9,7 +9,7 @@ The behavior of the security levels `STALE`, and `SECURE` has not changed.
 
 The default value for the Conclave configuration field `maxThreads` has been increased to 100. This value should be suitable
 to cover most of the use-cases when the logic inside the enclaves uses a large number of threads. There should be no
-considerable performance impact.
+major performance impact.
 
 ## 1.2 to 1.3
 

--- a/docs/docs/enclave-configuration.md
+++ b/docs/docs/enclave-configuration.md
@@ -45,7 +45,7 @@ conclave {
     enablePersistentMap = false
     maxPersistentMapSize = "16m"
     maxThreads = 100
-    supportLanguages = ""   
+    supportLanguages = ""
     reflectionConfigurationFiles.from("config.json")
     serializationConfigurationFiles.from("serialization.json")
 

--- a/docs/docs/enclave-configuration.md
+++ b/docs/docs/enclave-configuration.md
@@ -44,8 +44,9 @@ conclave {
     persistentFileSystemSize = "0m"
     enablePersistentMap = false
     maxPersistentMapSize = "16m"
-    maxThreads = 10
-    supportLanguages = ""
+    maxThreads = 100
+    enclaveWorkerThreads = 10
+    supportLanguages = ""   
     reflectionConfigurationFiles.from("config.json")
     serializationConfigurationFiles.from("serialization.json")
 
@@ -143,7 +144,7 @@ with 256Mb or more EPC.
     megabytes or gigabytes respectively.
 
 ### maxThreads
-_Default:_ `10`
+_Default:_ `100`
 
 This is an advanced setting that defines the maximum number of threads that can be active inside an enclave
 simultaneously. If you're interested, you can read [this detailed technical description](threads.md), otherwise you
@@ -154,6 +155,12 @@ can create inside the enclave.
 The `maxThreads` option defines how many EPC slots are available for threads that are simultaneously
 active inside the enclave. Setting a higher number for this results in a larger SGX EPC memory requirement
 for the enclave even if not all the thread slots are currently in use inside the enclave.
+
+### enclaveWorkerThreads
+_Default:_ `10`
+
+This is an advanced setting that defines the maximum number of threads available for processing the messages received by
+the enclave. The value of this field must be less than the value set in the field maxThreads.
 
 ### deadlockTimeout
 _Default:_ `10`

--- a/docs/docs/enclave-configuration.md
+++ b/docs/docs/enclave-configuration.md
@@ -45,7 +45,6 @@ conclave {
     enablePersistentMap = false
     maxPersistentMapSize = "16m"
     maxThreads = 100
-    enclaveWorkerThreads = 10
     supportLanguages = ""   
     reflectionConfigurationFiles.from("config.json")
     serializationConfigurationFiles.from("serialization.json")
@@ -155,12 +154,6 @@ can create inside the enclave.
 The `maxThreads` option defines how many EPC slots are available for threads that are simultaneously
 active inside the enclave. Setting a higher number for this results in a larger SGX EPC memory requirement
 for the enclave even if not all the thread slots are currently in use inside the enclave.
-
-### enclaveWorkerThreads
-_Default:_ `10`
-
-This is an advanced setting that defines the maximum number of threads available for processing the messages received by
-the enclave. The value of this field must be less than the value set in the field maxThreads.
 
 ### deadlockTimeout
 _Default:_ `10`

--- a/integration-tests/python-enclave/enclave/build.gradle
+++ b/integration-tests/python-enclave/enclave/build.gradle
@@ -5,9 +5,6 @@ plugins {
 conclave {
     productID = 100
     revocationLevel = 2
-    //  This is needed as Gramine would complain otherwise.
-    //  TODO: Make the maxThreads conditional to the runtime type (Gramine with and without Python, Graal) https://r3-cev.atlassian.net/browse/CON-1223
-    maxThreads = 32
 
     release {
         signingType = dummyKey

--- a/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/ConclaveExtension.kt
+++ b/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/ConclaveExtension.kt
@@ -17,7 +17,6 @@ open class ConclaveExtension @Inject constructor(objects: ObjectFactory) {
     val inMemoryFileSystemSize: Property<String> = objects.property(String::class.java).convention("64m")
     val persistentFileSystemSize: Property<String> = objects.property(String::class.java).convention("0")
     val maxThreads: Property<Int> = objects.property(Int::class.java).convention(100)
-    val enclaveWorkerThreads: Property<Int> = objects.property(Int::class.java).convention(10)
     val deadlockTimeout: Property<Int> = objects.property(Int::class.java).convention(10)
     val release: EnclaveExtension = objects.newInstance(EnclaveExtension::class.java)
     val debug: EnclaveExtension = objects.newInstance(EnclaveExtension::class.java)

--- a/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/ConclaveExtension.kt
+++ b/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/ConclaveExtension.kt
@@ -17,6 +17,7 @@ open class ConclaveExtension @Inject constructor(objects: ObjectFactory) {
     val inMemoryFileSystemSize: Property<String> = objects.property(String::class.java).convention("64m")
     val persistentFileSystemSize: Property<String> = objects.property(String::class.java).convention("0")
     val maxThreads: Property<Int> = objects.property(Int::class.java).convention(10)
+    val enclaveWorkerThreads: Property<Int> = objects.property(Int::class.java).convention(10)
     val deadlockTimeout: Property<Int> = objects.property(Int::class.java).convention(10)
     val release: EnclaveExtension = objects.newInstance(EnclaveExtension::class.java)
     val debug: EnclaveExtension = objects.newInstance(EnclaveExtension::class.java)

--- a/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/ConclaveExtension.kt
+++ b/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/ConclaveExtension.kt
@@ -16,7 +16,7 @@ open class ConclaveExtension @Inject constructor(objects: ObjectFactory) {
     val maxPersistentMapSize: Property<String> = objects.property(String::class.java).convention("16m")
     val inMemoryFileSystemSize: Property<String> = objects.property(String::class.java).convention("64m")
     val persistentFileSystemSize: Property<String> = objects.property(String::class.java).convention("0")
-    val maxThreads: Property<Int> = objects.property(Int::class.java).convention(10)
+    val maxThreads: Property<Int> = objects.property(Int::class.java).convention(100)
     val enclaveWorkerThreads: Property<Int> = objects.property(Int::class.java).convention(10)
     val deadlockTimeout: Property<Int> = objects.property(Int::class.java).convention(10)
     val release: EnclaveExtension = objects.newInstance(EnclaveExtension::class.java)

--- a/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/GradleEnclavePlugin.kt
+++ b/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/GradleEnclavePlugin.kt
@@ -201,6 +201,7 @@ class GradleEnclavePlugin @Inject constructor(private val layout: ProjectLayout)
             task.productId.set(conclaveExtension.productID)
             task.revocationLevel.set(conclaveExtension.revocationLevel)
             task.maxThreads.set(conclaveExtension.maxThreads)
+            task.enclaveWorkerThreads.set(conclaveExtension.enclaveWorkerThreads)
             task.manifestFile.set((gramineBuildDirectory / GRAMINE_MANIFEST).toFile())
         }
     }

--- a/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/GradleEnclavePlugin.kt
+++ b/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/GradleEnclavePlugin.kt
@@ -201,7 +201,6 @@ class GradleEnclavePlugin @Inject constructor(private val layout: ProjectLayout)
             task.productId.set(conclaveExtension.productID)
             task.revocationLevel.set(conclaveExtension.revocationLevel)
             task.maxThreads.set(conclaveExtension.maxThreads)
-            task.enclaveWorkerThreads.set(conclaveExtension.enclaveWorkerThreads)
             task.manifestFile.set((gramineBuildDirectory / GRAMINE_MANIFEST).toFile())
         }
     }

--- a/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/gramine/GenerateGramineDirectManifest.kt
+++ b/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/gramine/GenerateGramineDirectManifest.kt
@@ -38,9 +38,6 @@ open class GenerateGramineDirectManifest @Inject constructor(
     @get:Input
     val maxThreads: Property<Int> = objects.property(Int::class.java)
 
-    @get:Input
-    val enclaveWorkerThreads: Property<Int> = objects.property(Int::class.java)
-
     @get:InputFile
     val signingKey: RegularFileProperty = objects.fileProperty()
 
@@ -82,8 +79,8 @@ open class GenerateGramineDirectManifest @Inject constructor(
             "-Dpython_packages_path=$pythonPackagesPath",
             "-Dis_python_enclave=${pythonEnclave.get()}",
             "-Denclave_mode=${buildType.name.uppercase()}",
-            "-Denclave_worker_threads=$enclaveWorkerThreads",
-            "-Dgramine_max_threads=$maxThreads",
+            "-Denclave_worker_threads=10",
+            "-Dgramine_max_threads=${maxThreads.get()}",
             "-Denclave_size=${if (pythonEnclave.get()) PYTHON_ENCLAVE_SIZE else JAVA_ENCLAVE_SIZE}",
             manifestTemplateFile.absolutePathString(),
             manifestFile.asFile.get().absolutePath


### PR DESCRIPTION
The default value of `enclave_worker_threads` is set to 10.

Gramine's maximum threads will no longer be twice the value set in the `maxThreads` but instead the exact value provided in the `maxThreads` configuration field.

`maxThreads` default value has been set to 100. This value should cover most of the use-cases and it does not degrade the enclave performance nor does increases the memory usage of an enclave.

Removed the `maxThreads` configuration field from `integration-tests/python-enclave/enclave/build.gradle`

The docs were updated to include the new default value set for the maxThreads.