### PR TITLE
CON-1235: Fix issue with Gradle checking for input files are may not exist

### DIFF
--- a/integration-tests/general/common-test/src/main/kotlin/com/r3/conclave/integrationtests/general/commontest/TestUtils.kt
+++ b/integration-tests/general/common-test/src/main/kotlin/com/r3/conclave/integrationtests/general/commontest/TestUtils.kt
@@ -59,13 +59,6 @@ object TestUtils {
         assumeThat(runtimeType).isEqualTo(RuntimeType.GRAMINE)
     }
 
-    /**
-     * Create reference to a new temporary file within the directory without actually creating it.
-     */
-    fun Path.newTempFile(prefix: String? = null, suffix: String? = null): Path {
-        return Files.createTempFile(this, prefix, suffix).also(Path::deleteExisting)
-    }
-
     fun ZipFile.assertEntryExists(name: String): ZipEntry {
         val entry = getEntry(name)
         assertThat(entry).isNotNull

--- a/integration-tests/general/common-test/src/main/kotlin/com/r3/conclave/integrationtests/general/commontest/TestUtils.kt
+++ b/integration-tests/general/common-test/src/main/kotlin/com/r3/conclave/integrationtests/general/commontest/TestUtils.kt
@@ -59,6 +59,13 @@ object TestUtils {
         assumeThat(runtimeType).isEqualTo(RuntimeType.GRAMINE)
     }
 
+    /**
+     * Create reference to a new temporary file within the directory without actually creating it.
+     */
+    fun Path.newTempFile(prefix: String? = null, suffix: String? = null): Path {
+        return Files.createTempFile(this, prefix, suffix).also(Path::deleteExisting)
+    }
+
     fun ZipFile.assertEntryExists(name: String): ZipEntry {
         val entry = getEntry(name)
         assertThat(entry).isNotNull

--- a/integration-tests/plugin-tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/plugin/GraalVMEnclaveBundleJarTest.kt
+++ b/integration-tests/plugin-tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/plugin/GraalVMEnclaveBundleJarTest.kt
@@ -13,7 +13,6 @@ import com.r3.conclave.integrationtests.general.commontest.TestUtils.calculateMr
 import com.r3.conclave.integrationtests.general.commontest.TestUtils.enclaveMode
 import com.r3.conclave.integrationtests.general.commontest.TestUtils.execCommand
 import com.r3.conclave.integrationtests.general.commontest.TestUtils.getEnclaveSigstruct
-import com.r3.conclave.integrationtests.general.commontest.TestUtils.newTempFile
 import com.r3.conclave.integrationtests.general.commontest.TestUtils.readSigningKey
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -122,8 +121,8 @@ class GraalVMEnclaveBundleJarTest : AbstractPluginTaskTest() {
         }
         expectedMrsigner = calculateMrsigner(readSigningKey(userSigningKey))
 
-        val signatureFile = buildDir.newTempFile("signature", ".bin")
-        val publicKeyFile = buildDir.newTempFile("signing_public_key", ".pem")
+        val signatureFile = buildDir / "testExternalSigning-signature.bin"
+        val publicKeyFile = buildDir / "testExternalSigning-signing_public_key.pem"
 
         execCommand(
             "openssl", "rsa",
@@ -150,7 +149,7 @@ class GraalVMEnclaveBundleJarTest : AbstractPluginTaskTest() {
         val signingMaterial = defaultSigningMaterialFile.readBytes()
 
         println("Using user provided location for signing material output...")
-        val signingMaterialFile = buildDir.newTempFile("signing_material", ".bin")
+        val signingMaterialFile = buildDir / "testExternalSigning-signing_material.bin"
         // Insert signingMaterial config
         modifyGradleBuildFile(
             "signingType = externalKey",

--- a/integration-tests/plugin-tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/plugin/GraalVMEnclaveBundleJarTest.kt
+++ b/integration-tests/plugin-tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/plugin/GraalVMEnclaveBundleJarTest.kt
@@ -13,6 +13,7 @@ import com.r3.conclave.integrationtests.general.commontest.TestUtils.calculateMr
 import com.r3.conclave.integrationtests.general.commontest.TestUtils.enclaveMode
 import com.r3.conclave.integrationtests.general.commontest.TestUtils.execCommand
 import com.r3.conclave.integrationtests.general.commontest.TestUtils.getEnclaveSigstruct
+import com.r3.conclave.integrationtests.general.commontest.TestUtils.newTempFile
 import com.r3.conclave.integrationtests.general.commontest.TestUtils.readSigningKey
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -121,8 +122,8 @@ class GraalVMEnclaveBundleJarTest : AbstractPluginTaskTest() {
         }
         expectedMrsigner = calculateMrsigner(readSigningKey(userSigningKey))
 
-        val signatureFile = Files.createTempFile(buildDir, "signature", ".bin")
-        val publicKeyFile = Files.createTempFile(buildDir, "signing_public_key", ".pem")
+        val signatureFile = buildDir.newTempFile("signature", ".bin")
+        val publicKeyFile = buildDir.newTempFile("signing_public_key", ".pem")
 
         execCommand(
             "openssl", "rsa",
@@ -149,7 +150,7 @@ class GraalVMEnclaveBundleJarTest : AbstractPluginTaskTest() {
         val signingMaterial = defaultSigningMaterialFile.readBytes()
 
         println("Using user provided location for signing material output...")
-        val signingMaterialFile = Files.createTempFile(buildDir, "signing_material", ".bin")
+        val signingMaterialFile = buildDir.newTempFile("signing_material", ".bin")
         // Insert signingMaterial config
         modifyGradleBuildFile(
             "signingType = externalKey",

--- a/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/ConclaveExtension.kt
+++ b/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/ConclaveExtension.kt
@@ -40,8 +40,10 @@ open class ConclaveExtension @Inject constructor(objects: ObjectFactory) {
     @get:Input
     val runtime: Property<String> = objects.property(String::class.java)
     // Constants for the two types we support. Allows the user to not have to use string quotes if they don't want to.
+    @Suppress("unused")
     @get:Internal
     val graalvm = "graalvm"
+    @Suppress("unused")
     @get:Internal
     val gramine = "gramine"
 

--- a/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/ConclaveExtension.kt
+++ b/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/ConclaveExtension.kt
@@ -48,11 +48,11 @@ open class ConclaveExtension @Inject constructor(objects: ObjectFactory) {
     @get:Nested
     val kds: KDSExtension = objects.newInstance(KDSExtension::class.java)
 
-    @get:Nested
+    @get:Internal
     val release: EnclaveExtension = objects.newInstance(BuildType.Release)
-    @get:Nested
+    @get:Internal
     val debug: EnclaveExtension = objects.newInstance(BuildType.Debug)
-    @get:Nested
+    @get:Internal
     val simulation: EnclaveExtension = objects.newInstance(BuildType.Simulation)
 
     fun release(action: Action<EnclaveExtension>) {

--- a/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/ConclaveExtension.kt
+++ b/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/ConclaveExtension.kt
@@ -61,14 +61,17 @@ open class ConclaveExtension @Inject constructor(objects: ObjectFactory) {
         action.execute(release)
     }
 
+    @Suppress("unused")
     fun debug(action: Action<EnclaveExtension>) {
         action.execute(debug)
     }
 
+    @Suppress("unused")
     fun simulation(action: Action<EnclaveExtension>) {
         action.execute(simulation)
     }
 
+    @Suppress("unused")
     fun kds(action: Action<KDSExtension>) {
         action.execute(kds)
     }
@@ -83,10 +86,12 @@ open class KDSExtension @Inject constructor(objects: ObjectFactory) {
     @get:Nested
     val persistenceKeySpec: KeySpecExtension = objects.newInstance(KeySpecExtension::class.java)
 
+    @Suppress("unused")
     fun keySpec(action: Action<KeySpecExtension>) {
         action.execute(keySpec)
     }
 
+    @Suppress("unused")
     fun persistenceKeySpec(action: Action<KeySpecExtension>) {
         action.execute(persistenceKeySpec)
     }
@@ -103,6 +108,7 @@ open class KeySpecExtension @Inject constructor(objects: ObjectFactory) {
     @get:Nested
     val policyConstraint: PolicyConstraintExtension = objects.newInstance(PolicyConstraintExtension::class.java)
 
+    @Suppress("unused")
     fun policyConstraint(action: Action<PolicyConstraintExtension>) {
         action.execute(policyConstraint)
     }

--- a/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/EnclaveExtension.kt
+++ b/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/EnclaveExtension.kt
@@ -1,15 +1,9 @@
 package com.r3.conclave.plugin.enclave.gradle
 
 import org.gradle.api.file.ProjectLayout
-import org.gradle.api.file.RegularFile
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
-import org.gradle.api.provider.Provider
-import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputFile
-import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.Optional
 import java.util.*
 import javax.inject.Inject
 
@@ -19,43 +13,22 @@ open class EnclaveExtension @Inject constructor(
     projectLayout: ProjectLayout
 ) {
     // Define constants to make it easier for the configurer to select a signing type
-    @get:Internal
+    @Suppress("unused")
     val dummyKey = SigningType.DummyKey
-    @get:Internal
+    @Suppress("unused")
     val privateKey = SigningType.PrivateKey
-    @get:Internal
+    @Suppress("unused")
     val externalKey = SigningType.ExternalKey
 
-    @get:Input
     val signingType: Property<SigningType> = objects.property(SigningType::class.java).convention(
         // Release mode defaults to external signing, whilst the other two default to the dummy key.
         if (buildType == BuildType.Release) SigningType.ExternalKey else SigningType.DummyKey
     )
-    @get:InputFile
-    @get:Optional
     val mrsignerPublicKey: RegularFileProperty = objects.fileProperty()
-
-    @get:InputFile
-    @get:Optional
     val mrsignerSignature: RegularFileProperty = objects.fileProperty()
-
-    @get:Input
-    @get:Optional
     val signatureDate: Property<Date> = objects.property(Date::class.java)
-
-    @get:InputFile
-    @get:Optional
-    val signingMaterial: RegularFileProperty = objects.fileProperty()
-
-    // In theory it should have been possible to add .convention() to signingMaterial above with the default, but
-    // it doesn't work as Gradle expects the file to exist. So instead we create this read-only Provider which
-    // should be used by tasks instead.
-    @get:Internal
-    val signingMaterialWithDefault: Provider<RegularFile> = signingMaterial.orElse(
+    val signingMaterial: RegularFileProperty = objects.fileProperty().convention(
         projectLayout.buildDirectory.file("enclave/${buildType.name.lowercase()}/signing_material.bin")
     )
-
-    @get:InputFile
-    @get:Optional
     val signingKey: RegularFileProperty = objects.fileProperty()
 }

--- a/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/GradleEnclavePlugin.kt
+++ b/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/GradleEnclavePlugin.kt
@@ -412,7 +412,7 @@ class GradleEnclavePlugin @Inject constructor(private val layout: ProjectLayout)
                 task.inputEnclave.set(buildUnsignedEnclaveTask.outputEnclave)
                 task.inputEnclaveConfig.set(generateEnclaveConfigTask.outputConfigFile)
                 task.signatureDate.set(enclaveExtension.signatureDate)
-                task.outputSigningMaterial.set(enclaveExtension.signingMaterialWithDefault)
+                task.outputSigningMaterial.set(enclaveExtension.signingMaterial)
             }
 
             val addEnclaveSignatureTask = target.createTask<AddEnclaveSignature>(


### PR DESCRIPTION
Certain input file parameters in the enclave's Gradle config may not exist when the build process begins. These include `mrsignerSignature` and `signingMaterial`. These particular files are only created in the first-pass of the `externalKey` signing process (when `generateEnclaveSigningMaterial` is invoked), and their existence is only required in the second-pass.

The previous changes to make sure all the plugin tasks are "incremental" incorrectly marked the `EnclaveExtension` config objects as inputs to the `GenerateEnclaveProperties` task. `GenerateEnclaveProperties` only needs the properties of the parent `ConclaveExtension` object as inputs. To fix this, the `release`, `debug`, and `simulation` properties are now marked as `@Internal` and not `@Nested`.