### PR TITLE
CON-1178: Fix certificate issues of AESM service

### DIFF
--- a/containers/aesmd/Dockerfile
+++ b/containers/aesmd/Dockerfile
@@ -14,6 +14,9 @@ RUN DEBIAN_FRONTEND=noninteractive  apt-get install -y \
 RUN wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add -
 RUN echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu focal main' > /etc/apt/sources.list.d/intel-sgx.list
 
+RUN wget -qO - https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
+RUN echo 'deb [arch=amd64] https://packages.microsoft.com/ubuntu/20.04/prod focal main' > /etc/apt/sources.list.d/msprod.list
+
 RUN apt-get update
 
 # TODO: Update Conclave to Intel SGX SDK 2.18 and remove package versions: https://r3-cev.atlassian.net/browse/CON-1243
@@ -33,7 +36,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
     libsgx-launch=2.17.100.3-focal1 \
     libsgx-pce-logic=1.14.100.3-focal1 \
     libsgx-qe3-logic=1.14.100.3-focal1 \
-    libsgx-urts=2.17.100.3-focal1
+    libsgx-urts=2.17.100.3-focal1 \
+    az-dcap-client
+
 
 # Need to set LD_LIBRARY_PATH to directory of aesm_service executable
 WORKDIR /opt/intel/sgx-aesm-service/aesm

--- a/containers/integration-tests-build/Dockerfile
+++ b/containers/integration-tests-build/Dockerfile
@@ -16,7 +16,6 @@ RUN echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu foc
 
 RUN apt-get -y update
 
-
 # Disable interactive dialogue
 # Otherwise, a message that requires user input might appear during the installation
 # TODO: Update Conclave to Intel SGX SDK 2.18 and remove package versions: https://r3-cev.atlassian.net/browse/CON-1243
@@ -35,4 +34,3 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
     libsgx-pce-logic=1.14.100.3-focal1 \
     libsgx-qe3-logic=1.14.100.3-focal1 \
     libsgx-urts=2.17.100.3-focal1
-

--- a/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/ThreadSafeEnclaveTests.kt
+++ b/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/ThreadSafeEnclaveTests.kt
@@ -89,7 +89,7 @@ class ThreadSafeEnclaveTests : AbstractEnclaveActionTest("com.r3.conclave.integr
 
     @Test
     fun `threading inside enclave`() {
-        val n = 8 // <= thread safe enclave maxThreads (10)
+        val n = 38 // <= thread safe enclave maxThreads (40)
         val result = callEnclave(TooManyThreadsRequestedAction(n))
         assertThat(result).isEqualTo((n * (n + 1)) / 2)
     }
@@ -99,7 +99,7 @@ class ThreadSafeEnclaveTests : AbstractEnclaveActionTest("com.r3.conclave.integr
         // This test hangs when tearing down the enclave, so we disable teardown here.
         // TODO: CON-1244 Figure out why this test hangs, then remove this teardown logic.
         doEnclaveTeardown = false
-        val n = 15 // > thread safe enclave maxThreads (10)
+        val n = 45 // > thread safe enclave maxThreads (40)
         assertThatThrownBy {
             callEnclave(TooManyThreadsRequestedAction(n))
         }.hasMessageContaining("The enclave ran out of TCS slots when calling from a new thread into the enclave.") // SGX_ERROR_OUT_OF_TCS

--- a/integration-tests/general/threadsafe-enclave/build.gradle
+++ b/integration-tests/general/threadsafe-enclave/build.gradle
@@ -11,7 +11,7 @@ conclave {
     productID = 1
     revocationLevel = 0
     runtime = runtimeType
-    maxThreads = 10         // To match assumptions in tests
+    maxThreads = 40         // To match assumptions in tests
 
     kds {
         kdsEnclaveConstraint = "S:B4CDF6F4FA5B484FCA82292CE340FF305AA294F19382178BEA759E30E7DCFE2D PROD:1 SEC:INSECURE"


### PR DESCRIPTION
With the previous changes we have introduced the AESM service. This works but it is currently throwing an exception related to missing certificates. The root cause of the problem is that AESM service needs the Azure DCAP Client in order to retrieve such certificates and therefore we need to add it to the related AESM container.
This PR adds that.

In order to make an integration test pass (`MockEnclaveEnvironmentHardwareCompatibilityTest`), we also have to increase the `maxThread` value of the enclave used in that test