### PR TITLE
CON-1208: Put Jep in sync across Java and Python

### DIFF
--- a/containers/conclave-build/Dockerfile
+++ b/containers/conclave-build/Dockerfile
@@ -30,6 +30,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
         openjdk-17-jdk-headless
 ENV JAVA_HOME /usr/lib/jvm/java-17-openjdk-amd64
 
-RUN pip3 install jep
+ARG jep_version
+RUN pip3 install jep==$jep_version
 
 CMD java -version

--- a/containers/scripts/ci_build_publish_docker_images.sh
+++ b/containers/scripts/ci_build_publish_docker_images.sh
@@ -19,8 +19,8 @@ script_dir=$containers_script_dir/../../scripts
 source ${script_dir}/ci_build_common.sh
 source ${containers_script_dir}/common.sh
 
-# Git commit id
 commit_id=$(getGitCommitId)
+jep_version=$(getJepVersion)
 
 # Downloads or copys Graal from a local directory. This is required for building the sdk build.
 downloadOrCopyGraal() {
@@ -60,21 +60,21 @@ buildContainerSDKBuild() {
     downloadOrCopyGraal
   fi
 
-  docker build -t $container_image_sdk_build --build-arg commit_id=$commit_id .
+  docker build -t $container_image_sdk_build --build-arg commit_id=$commit_id --build-arg jep_version="$jep_version" .
   popd
 }
 
 # Builds conclave-build docker image
 buildContainerConclaveBuild() {
   pushd "${code_host_dir}/containers/conclave-build/"
-  docker build -t $container_image_conclave_build --build-arg commit_id=$commit_id .
+  docker build -t $container_image_conclave_build --build-arg commit_id=$commit_id --build-arg jep_version="$jep_version" .
   popd
 }
 
 # Builds integration-tests-build docker image (N.B.: Must be built after the conclave-build.)
 buildContainerIntegrationTestsBuild() {
   pushd "${code_host_dir}/containers/integration-tests-build"
-  docker build -t $container_image_integration_tests_build --build-arg container_base_image=$container_image_conclave_build --build-arg commit_id=$commit_id .
+  docker build -t $container_image_integration_tests_build --build-arg container_base_image=$container_image_conclave_build --build-arg commit_id=$commit_id --build-arg jep_version="$jep_version" .
   popd
 }
 

--- a/containers/scripts/common.sh
+++ b/containers/scripts/common.sh
@@ -22,6 +22,10 @@ function getGitCommitId() {
   git rev-parse HEAD
 }
 
+function getJepVersion() {
+  getVersionValueFromVersionsFile jep_version
+}
+
 # Returns 0 if the docker image exists. Otherwise, 1.
 # Returning zero as true is strange but that is the convention with bash shell.
 # N.B. The image might exist locally and not on the remote server

--- a/containers/sdk-build/src/docker/Dockerfile
+++ b/containers/sdk-build/src/docker/Dockerfile
@@ -107,7 +107,8 @@ RUN mkdir -p $NEXUS_IQ_HOME
 RUN wget -O $NEXUS_IQ_HOME/nexus-iq-cli.jar https://download.sonatype.com/clm/scanner/nexus-iq-cli-1.131.0-01.jar
 RUN echo "f9159984056cee4576f34fcfa6f33ccab42b070e  $NEXUS_IQ_HOME/nexus-iq-cli.jar" | shasum -c -
 
-RUN pip3 install jep
+ARG jep_version
+RUN pip3 install jep==$jep_version
 
 # Add jep to the library path
 ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/lib/python3.8/dist-packages/jep"

--- a/plugin-enclave-gradle/build.gradle
+++ b/plugin-enclave-gradle/build.gradle
@@ -73,7 +73,13 @@ processResources {
 
     // conclave-build Dockerfile
     into("conclave-build") {
-        from("${rootProject.projectDir}/containers/conclave-build")
+        from("${rootProject.projectDir}/containers/conclave-build") {
+	    include "Dockerfile"
+	}
+
+        from("${rootProject.projectDir}") {
+            include "versions.gradle"
+        }
     }
 
     // C common headers

--- a/plugin-enclave-gradle/build.gradle
+++ b/plugin-enclave-gradle/build.gradle
@@ -73,13 +73,7 @@ processResources {
 
     // conclave-build Dockerfile
     into("conclave-build") {
-        from("${rootProject.projectDir}/containers/conclave-build") {
-	    include "Dockerfile"
-	}
-
-        from("${rootProject.projectDir}") {
-            include "versions.gradle"
-        }
+        from("${rootProject.projectDir}/containers/conclave-build")
     }
 
     // C common headers

--- a/plugin-enclave-gradle/build.gradle
+++ b/plugin-enclave-gradle/build.gradle
@@ -167,6 +167,7 @@ processResources {
 jar {
     manifest {
         // This is used in the plugin to add implicit dependencies of the right version.
-        attributes("Conclave-Version": rootProject.version.toString())
+        attributes("Conclave-Version": rootProject.version.toString(),
+                   "Jep-Version": jep_version.toString())
     }
 }

--- a/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/GradleEnclavePlugin.kt
+++ b/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/GradleEnclavePlugin.kt
@@ -43,12 +43,14 @@ class GradleEnclavePlugin @Inject constructor(private val layout: ProjectLayout)
     companion object {
         private const val CONCLAVE_GRAALVM_VERSION = "22.0.0.2-1.4-SNAPSHOT"
 
-        private val CONCLAVE_SDK_VERSION = run {
-            GradleEnclavePlugin::class.java.classLoader
+        private val CONCLAVE_SDK_VERSION = retrievePackageVersionFromManifest("Conclave-Version")
+
+        fun retrievePackageVersionFromManifest(packageName: String): String {
+            return GradleEnclavePlugin::class.java.classLoader
                 .getResources(MANIFEST_NAME)
                 .asSequence()
-                .mapNotNull { it.openStream().use(::Manifest).mainAttributes.getValue("Conclave-Version") }
-                .firstOrNull() ?: throw IllegalStateException("Could not find Conclave-Version in plugin's manifest")
+                .mapNotNull { it.openStream().use(::Manifest).mainAttributes.getValue(packageName) }
+                .firstOrNull() ?: throw IllegalStateException("Could not find $packageName in plugin's manifest")
         }
     }
 

--- a/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/LinuxExec.kt
+++ b/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/LinuxExec.kt
@@ -1,5 +1,6 @@
 package com.r3.conclave.plugin.enclave.gradle
 
+import com.r3.conclave.plugin.enclave.gradle.GradleEnclavePlugin.Companion.retrievePackageVersionFromManifest
 import com.r3.conclave.utilities.internal.copyResource
 import org.gradle.api.GradleException
 import org.gradle.api.model.ObjectFactory
@@ -10,21 +11,12 @@ import java.io.File
 import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption.REPLACE_EXISTING
-import java.util.jar.JarFile
-import java.util.jar.Manifest
 import javax.inject.Inject
 
 open class LinuxExec @Inject constructor(objects: ObjectFactory) : ConclaveTask() {
 
     companion object {
-
-        private val JEP_VERSION = run {
-            LinuxExec::class.java.classLoader
-                .getResources(JarFile.MANIFEST_NAME)
-                .asSequence()
-                .mapNotNull { it.openStream().use(::Manifest).mainAttributes.getValue("Jep-Version") }
-                .firstOrNull() ?: throw IllegalStateException("Could not find Conclave-Version in plugin's manifest")
-        }
+        private val JEP_VERSION = retrievePackageVersionFromManifest("Jep-Version")
     }
 
     @get:Input

--- a/versions.gradle
+++ b/versions.gradle
@@ -26,6 +26,6 @@ ext {
     h2database_h2_version = '1.4.200'
     httpclient5_version = '5.1.3'
     ktor_version = '2.1.2'
-    jep_version = '4.0.3'
+    jep_version = '4.1.0'
     tomlj_version = '1.1.0'
 }


### PR DESCRIPTION
In this patch we put in sync the libraries of JEP, which is installed both on the Java/Kotlin side and Python.
We also update it to 4.1.0
