### PR TITLE
Removed BuildType enum from plugin code

### DIFF
--- a/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/BuildType.kt
+++ b/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/BuildType.kt
@@ -1,8 +1,0 @@
-package com.r3.conclave.plugin.enclave.gradle
-
-enum class BuildType {
-    Mock,
-    Simulation,
-    Debug,
-    Release
-}

--- a/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/ConclaveExtension.kt
+++ b/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/ConclaveExtension.kt
@@ -1,5 +1,6 @@
 package com.r3.conclave.plugin.enclave.gradle
 
+import com.r3.conclave.common.EnclaveMode
 import org.gradle.api.Action
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.model.ObjectFactory
@@ -52,12 +53,13 @@ open class ConclaveExtension @Inject constructor(objects: ObjectFactory) {
     val kds: KDSExtension = objects.newInstance(KDSExtension::class.java)
 
     @get:Internal
-    val release: EnclaveExtension = objects.newInstance(BuildType.Release)
+    val release: EnclaveExtension = objects.newInstance(EnclaveMode.RELEASE)
     @get:Internal
-    val debug: EnclaveExtension = objects.newInstance(BuildType.Debug)
+    val debug: EnclaveExtension = objects.newInstance(EnclaveMode.DEBUG)
     @get:Internal
-    val simulation: EnclaveExtension = objects.newInstance(BuildType.Simulation)
+    val simulation: EnclaveExtension = objects.newInstance(EnclaveMode.SIMULATION)
 
+    @Suppress("unused")
     fun release(action: Action<EnclaveExtension>) {
         action.execute(release)
     }

--- a/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/EnclaveExtension.kt
+++ b/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/EnclaveExtension.kt
@@ -1,5 +1,6 @@
 package com.r3.conclave.plugin.enclave.gradle
 
+import com.r3.conclave.common.EnclaveMode
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
@@ -9,8 +10,8 @@ import javax.inject.Inject
 
 open class EnclaveExtension @Inject constructor(
     objects: ObjectFactory,
-    buildType: BuildType,
-    projectLayout: ProjectLayout
+    projectLayout: ProjectLayout,
+    val enclaveMode: EnclaveMode
 ) {
     // Define constants to make it easier for the configurer to select a signing type
     @Suppress("unused")
@@ -22,13 +23,13 @@ open class EnclaveExtension @Inject constructor(
 
     val signingType: Property<SigningType> = objects.property(SigningType::class.java).convention(
         // Release mode defaults to external signing, whilst the other two default to the dummy key.
-        if (buildType == BuildType.Release) SigningType.ExternalKey else SigningType.DummyKey
+        if (enclaveMode == EnclaveMode.RELEASE) SigningType.ExternalKey else SigningType.DummyKey
     )
     val mrsignerPublicKey: RegularFileProperty = objects.fileProperty()
     val mrsignerSignature: RegularFileProperty = objects.fileProperty()
     val signatureDate: Property<Date> = objects.property(Date::class.java)
     val signingMaterial: RegularFileProperty = objects.fileProperty().convention(
-        projectLayout.buildDirectory.file("enclave/${buildType.name.lowercase()}/signing_material.bin")
+        projectLayout.buildDirectory.file("enclave/${enclaveMode.name.lowercase()}/signing_material.bin")
     )
     val signingKey: RegularFileProperty = objects.fileProperty()
 }

--- a/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/GenerateEnclaveConfig.kt
+++ b/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/GenerateEnclaveConfig.kt
@@ -1,5 +1,6 @@
 package com.r3.conclave.plugin.enclave.gradle
 
+import com.r3.conclave.common.EnclaveMode
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
@@ -9,7 +10,10 @@ import org.gradle.api.tasks.OutputFile
 import java.nio.file.Files
 import javax.inject.Inject
 
-open class GenerateEnclaveConfig @Inject constructor(objects: ObjectFactory, private val buildType: BuildType) : ConclaveTask() {
+open class GenerateEnclaveConfig @Inject constructor(
+    objects: ObjectFactory,
+    private val enclaveMode: EnclaveMode
+) : ConclaveTask() {
     @get:Input
     val productID: Property<Int> = objects.property(Int::class.java)
     @get:Input
@@ -49,7 +53,7 @@ open class GenerateEnclaveConfig @Inject constructor(objects: ObjectFactory, pri
         val maxStackSizeBytes = getSizeBytes(maxStackSize.get())
         val maxHeapSizeBytes = getSizeBytes(maxHeapSize.get())
 
-        val disableDebug = if (buildType == BuildType.Release) 1 else 0
+        val disableDebug = if (enclaveMode == EnclaveMode.RELEASE) 1 else 0
 
         val content = """
             <EnclaveConfiguration>

--- a/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/GenerateEnclaveMetadata.kt
+++ b/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/GenerateEnclaveMetadata.kt
@@ -1,5 +1,6 @@
 package com.r3.conclave.plugin.enclave.gradle
 
+import com.r3.conclave.common.EnclaveMode
 import com.r3.conclave.common.SHA256Hash
 import com.r3.conclave.common.internal.Cursor
 import com.r3.conclave.common.internal.SgxCssBody.enclaveHash
@@ -19,7 +20,7 @@ import kotlin.io.path.readBytes
 open class GenerateEnclaveMetadata @Inject constructor(
     objects: ObjectFactory,
     private val plugin: GradleEnclavePlugin,
-    private val buildType: BuildType,
+    private val enclaveMode: EnclaveMode,
     private val linuxExec: LinuxExec
 ) : ConclaveTask() {
     @get:InputFile
@@ -61,12 +62,7 @@ open class GenerateEnclaveMetadata @Inject constructor(
         logger.lifecycle("Enclave code hash:   ${SHA256Hash.get(enclaveMetadata[body][enclaveHash].read())}")
         logger.lifecycle("Enclave code signer: ${enclaveMetadata[key].mrsigner}")
 
-        val buildTypeString = buildType.toString().uppercase()
-        val buildSecurityString = when (buildType) {
-            BuildType.Release -> "SECURE"
-            else -> "INSECURE"
-        }
-
-        logger.lifecycle("Enclave mode:        $buildTypeString ($buildSecurityString)")
+        val buildSecurityString = if (enclaveMode == EnclaveMode.RELEASE) "SECURE" else "INSECURE"
+        logger.lifecycle("Enclave mode:        $enclaveMode ($buildSecurityString)")
     }
 }

--- a/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/SignEnclave.kt
+++ b/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/SignEnclave.kt
@@ -13,8 +13,6 @@ import kotlin.io.path.absolutePathString
 open class SignEnclave @Inject constructor(
     objects: ObjectFactory,
     private val plugin: GradleEnclavePlugin,
-    private val enclaveExtension: EnclaveExtension,
-    private val buildType: BuildType,
     private val linuxExec: LinuxExec
 ) : ConclaveTask() {
     @get:InputFile


### PR DESCRIPTION
BuildType is a duplication of EnclaveMode and the plugin code has been updated to use this instead.

Also refactored the plugin code a bit to make it more clear that the enclave bundle jar task needs to be added to the enclave mode configuration object (`registerCrossProjectArtifact` method).