### PR TITLE
Remove reference to upcoming 1.3.1 features in release notes

### DIFF
--- a/docs/docs/release-notes.md
+++ b/docs/docs/release-notes.md
@@ -1,9 +1,5 @@
 # Release notes
 
-## 1.3.1
-1. To make deploying enclaves built with conclave easier, files containing the enclave code hash and signer are now 
-   generated when an enclave is built. See [here](enclave-configuration.md#enclave-build-process) for more information.
-
 ## 1.3
 
 1. :tada: **The Conclave Core SDK is now open source!** :tada: Read our


### PR DESCRIPTION
These need to be added once we release 1.3.1 GA.