### PR TITLE
Revert "[CON-1135] Gradle plugin to output enclave metadata to file"

### DIFF
--- a/docs/docs/enclave-configuration.md
+++ b/docs/docs/enclave-configuration.md
@@ -316,28 +316,6 @@ The path should be absolute or relative to the root of the enclave module.
     when building on Windows and macOS platforms. Additionally, on Windows, paths must use forwardslashes rather than
     the usual backslashes.
 
-## Enclave build process
-
-The Conclave gradle plugin automates the process of building a Conclave enclave and packaging it so that it can be
-instantiated elsewhere in a project.
-
-### Code hash and signer output
-
-When a Conclave enclave is built, information about the enclave is printed during the build process:
-
-```
-Enclave code hash:   4BEF016A8D35E04FCCFDDB725CE678C29A3FC284F47723869961334CED4C2A55
-Enclave code signer: 4924CA3A9C8241A3C0AA1A24A407AA86401D2B79FA9FF84932DA798A942166D4
-Enclave mode:        SIMULATION (INSECURE)
-```
-
-These values can then be used by attesting parties as part of an [enclave constraints](constraints.md) string.
-
-The code hash and signer are also written to files in the enclave module build directory at the following paths:
-
-- Code hash: `<enclave-module-dir>/build/conclave/<enclave-mode>/mrenclave`
-- Code signer: `<enclave-module-dir>/build/conclave/<enclave-mode>/mrsigner`
-
 ## Assisted configuration of Native Image builds
 
 You can generate the reflection and serialization configuration files by using the

--- a/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/GenerateEnclaveMetadata.kt
+++ b/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/GenerateEnclaveMetadata.kt
@@ -1,10 +1,8 @@
 package com.r3.conclave.plugin.enclave.gradle
 
-import com.r3.conclave.utilities.internal.toHexString
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.InputFile
-import org.gradle.api.tasks.OutputFile
 import org.gradle.internal.os.OperatingSystem
 import javax.inject.Inject
 import kotlin.io.path.absolutePathString
@@ -17,12 +15,6 @@ open class GenerateEnclaveMetadata @Inject constructor(
 ) : ConclaveTask() {
     @get:InputFile
     val inputSignedEnclave: RegularFileProperty = objects.fileProperty()
-
-    @get:OutputFile
-    val mrsignerOutputFile: RegularFileProperty = objects.fileProperty()
-
-    @get:OutputFile
-    val mrenclaveOutputFile: RegularFileProperty = objects.fileProperty()
 
     override fun action() {
         val metadataFile = temporaryDir.toPath().resolve("enclave_metadata.txt")
@@ -48,10 +40,6 @@ open class GenerateEnclaveMetadata @Inject constructor(
         }
 
         val enclaveMetadata = EnclaveMetadata.parseMetadataFile(metadataFile)
-
-        mrsignerOutputFile.asFile.get().writeText(enclaveMetadata.mrsigner.bytes.toHexString().uppercase())
-        mrenclaveOutputFile.asFile.get().writeText(enclaveMetadata.mrenclave.bytes.toHexString().uppercase())
-
         logger.lifecycle("Enclave code hash:   ${enclaveMetadata.mrenclave}")
         logger.lifecycle("Enclave code signer: ${enclaveMetadata.mrsigner}")
 


### PR DESCRIPTION
This reverts commit d1f9bbdd5ef32a8a37d4fda3913ae4e4382c9fea from the release/1.3 branch, but it will still be present in the new release/1.3.1 branch.