### PR TITLE
CON-1203: Non-Linux envs must always use Docker for building the enclave

### DIFF
--- a/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/AddEnclaveSignature.kt
+++ b/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/AddEnclaveSignature.kt
@@ -36,21 +36,21 @@ open class AddEnclaveSignature @Inject constructor(
     val outputSignedEnclave: RegularFileProperty = objects.fileProperty()
 
     override fun action() {
-        if (buildInDocker.get()) {
+        if (linuxExec.buildInDocker(buildInDocker)) {
             try {
                 // The input key files may not live in a directory accessible by docker.
                 // Prepare the files so docker can access them if necessary.
-                val mrSignerPublicKey = linuxExec.prepareFile(inputMrsignerPublicKey.asFile.get())
-                val mrSignerSignature = linuxExec.prepareFile(inputMrsignerSignature.asFile.get())
+                val mrSignerPublicKey = linuxExec.prepareFile(inputMrsignerPublicKey.asFile.get().toPath())
+                val mrSignerSignature = linuxExec.prepareFile(inputMrsignerSignature.asFile.get().toPath())
 
                 linuxExec.exec(
                     listOf<String>(
                         plugin.signToolPath().absolutePathString(), "catsig",
-                        "-key", mrSignerPublicKey.absolutePath,
+                        "-key", mrSignerPublicKey.absolutePathString(),
                         "-enclave", inputEnclave.asFile.get().absolutePath,
                         "-out", outputSignedEnclave.asFile.get().absolutePath,
                         "-config", inputEnclaveConfig.asFile.get().absolutePath,
-                        "-sig", mrSignerSignature.absolutePath,
+                        "-sig", mrSignerSignature.absolutePathString(),
                         "-unsigned", inputSigningMaterial.asFile.get().absolutePath
                     )
                 )

--- a/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/GenerateEnclaveMetadata.kt
+++ b/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/GenerateEnclaveMetadata.kt
@@ -34,7 +34,7 @@ open class GenerateEnclaveMetadata @Inject constructor(
         //  See TestUtils.getEnclaveSigstruct in the integration tests.
         val metadataFile = temporaryDir.toPath().resolve("enclave_css.bin")
 
-        if (buildInDocker.get()) {
+        if (linuxExec.buildInDocker(buildInDocker)) {
             try {
                 linuxExec.exec(
                     listOf<String>(

--- a/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/GenerateEnclaveSigningMaterial.kt
+++ b/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/GenerateEnclaveSigningMaterial.kt
@@ -7,13 +7,16 @@ import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.OutputFile
-import java.io.File
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
+import java.nio.file.Path
 import java.text.SimpleDateFormat
 import java.util.*
 import javax.inject.Inject
 import kotlin.io.path.absolutePathString
+import kotlin.io.path.exists
+import kotlin.io.path.readBytes
+import kotlin.io.path.writeBytes
 
 open class GenerateEnclaveSigningMaterial @Inject constructor(
     objects: ObjectFactory,
@@ -40,17 +43,17 @@ open class GenerateEnclaveSigningMaterial @Inject constructor(
     val outputSigningMaterial: RegularFileProperty = objects.fileProperty()
 
     override fun action() {
-        val dockerOutputSigningFile: File?
-        if (buildInDocker.get()) {
+        val dockerOutputSigningFile: Path?
+        if (linuxExec.buildInDocker(buildInDocker)) {
             // The signing material file may not live in a directory accessible by docker.
             // Prepare the file so docker can access it if necessary.
-            dockerOutputSigningFile = linuxExec.prepareFile(outputSigningMaterial.asFile.get())
+            dockerOutputSigningFile = linuxExec.prepareFile(outputSigningMaterial.asFile.get().toPath())
 
             linuxExec.exec(
                 listOf<String>(
                     plugin.signToolPath().absolutePathString(), "gendata",
                     "-enclave", inputEnclave.asFile.get().absolutePath,
-                    "-out", dockerOutputSigningFile.absolutePath,
+                    "-out", dockerOutputSigningFile.absolutePathString(),
                     "-config", inputEnclaveConfig.asFile.get().absolutePath
                 )
             )
@@ -70,8 +73,8 @@ open class GenerateEnclaveSigningMaterial @Inject constructor(
         }
     }
 
-    private fun postProcess(dockerOutputSigningFile: File?) {
-        val outputSigningMaterial = outputSigningMaterial.asFile.get()
+    private fun postProcess(dockerOutputSigningFile: Path?) {
+        val outputSigningMaterial = outputSigningMaterial.asFile.get().toPath()
         val signingFile = dockerOutputSigningFile ?: outputSigningMaterial
         if (!signingFile.exists()) {
             throw GradleException("sign_tool output is missing")
@@ -86,6 +89,6 @@ open class GenerateEnclaveSigningMaterial @Inject constructor(
             putInt(encodedSigDate)
         }
         outputSigningMaterial.writeBytes(data)
-        project.logger.lifecycle("Enclave signing materials: ${outputSigningMaterial.absolutePath}")
+        project.logger.lifecycle("Enclave signing materials: ${outputSigningMaterial.absolutePathString()}")
     }
 }

--- a/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/GradleEnclavePlugin.kt
+++ b/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/GradleEnclavePlugin.kt
@@ -30,6 +30,7 @@ import org.gradle.util.VersionNumber
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.attribute.PosixFilePermission.OWNER_EXECUTE
+import java.util.*
 import java.util.jar.JarFile.MANIFEST_NAME
 import java.util.jar.Manifest
 import java.util.stream.Collectors.toList
@@ -40,14 +41,19 @@ class GradleEnclavePlugin @Inject constructor(private val layout: ProjectLayout)
     companion object {
         private const val CONCLAVE_GRAALVM_VERSION = "22.0.0.2-1.4-SNAPSHOT"
 
-        private val CONCLAVE_SDK_VERSION = retrievePackageVersionFromManifest("Conclave-Version")
+        private val CONCLAVE_SDK_VERSION = getManifestAttribute("Conclave-Version")
 
-        fun retrievePackageVersionFromManifest(packageName: String): String {
-            return GradleEnclavePlugin::class.java.classLoader
+        fun getManifestAttribute(name: String): String {
+            // Scan all MANIFEST.MF files in the plugin's classpath and find the given manifest attribute.
+            val values = GradleEnclavePlugin::class.java.classLoader
                 .getResources(MANIFEST_NAME)
                 .asSequence()
-                .mapNotNull { it.openStream().use(::Manifest).mainAttributes.getValue(packageName) }
-                .firstOrNull() ?: throw IllegalStateException("Could not find $packageName in plugin's manifest")
+                .mapNotNullTo(TreeSet()) { it.openStream().use(::Manifest).mainAttributes.getValue(name) }
+            return when (values.size) {
+                1 -> values.first()
+                0 -> throw IllegalStateException("Could not find manifest attribute $name")
+                else -> throw IllegalStateException("Found multiple values for manifest attribute $name: $values")
+            }
         }
     }
 

--- a/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/LinuxExec.kt
+++ b/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/LinuxExec.kt
@@ -6,12 +6,18 @@ import org.gradle.api.GradleException
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
+import org.gradle.internal.os.OperatingSystem
 import java.io.ByteArrayOutputStream
 import java.io.File
-import java.io.IOException
 import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
 import java.nio.file.StandardCopyOption.REPLACE_EXISTING
 import javax.inject.Inject
+import kotlin.io.path.createDirectories
+import kotlin.io.path.exists
+import kotlin.io.path.extension
+import kotlin.io.path.nameWithoutExtension
 
 open class LinuxExec @Inject constructor(objects: ObjectFactory) : ConclaveTask() {
 
@@ -37,7 +43,7 @@ open class LinuxExec @Inject constructor(objects: ObjectFactory) : ConclaveTask(
         // Building the enclave requires docker container to make the experience consistent between all OSs.
         // This helps with using Gramine too, as it's included in the docker container and users don't need to
         // installed it by themselves. Only Python Gramine enclaves are built outside the container.
-        if (buildInDocker.get()) {
+        if (buildInDocker(buildInDocker)) {
             val conclaveBuildDir = temporaryDir.toPath() / "conclave-build"
             LinuxExec::class.java.copyResource("/conclave-build/Dockerfile", conclaveBuildDir / "Dockerfile")
 
@@ -52,16 +58,32 @@ open class LinuxExec @Inject constructor(objects: ObjectFactory) : ConclaveTask(
                     conclaveBuildDir
                 )
             } catch (e: Exception) {
-                logger.info("Docker build of conclave-build failed.", e)
-                throw GradleException(
-                    "Conclave requires Docker to be installed when building GraalVM native-image based enclaves. "
-                            + "Please install Docker and rerun your build. "
-                            + "See https://docs.conclave.net/enclave-modes.html#system-requirements "
-                            + "If the build still fails, please rerun the build with '--info' flag and create a new "
-                            + "issue on GitHub https://github.com/R3Conclave/conclave-core-sdk/issues/new"
-                )
+                val message = if (OperatingSystem.current().isLinux) {
+                    "Conclave requires Docker to be installed when building enclaves. Please install Docker and " +
+                            "rerun your build. See https://docs.conclave.net/enclave-modes.html#system-requirements " +
+                            "for more information. If the build still fails, please rerun the build with the " +
+                            "--stacktrace flag and raise an issue at https://github.com/R3Conclave/conclave-core-sdk/issues/new"
+                } else {
+                    "Conclave requires Docker to be installed when building enclaves on non-Linux platforms. Please " +
+                            "install Docker and rerun your build. See " +
+                            "https://docs.conclave.net/tutorial.html#setting-up-your-machine and " +
+                            "https://docs.conclave.net/writing-hello-world.html#configure-the-enclave-module for " +
+                            "more information."
+                }
+                throw GradleException(message, e)
             }
         }
+    }
+
+    /**
+     * Non-Linux environments must always use Docker.
+     */
+    // We pass in the [buildInDocker] as a parameter, even though this task also has the same property, to make sure
+    // the caller task re-runs if the buildInDocker config changes.
+    // TODO Come up with a better way than this. This might not be an issue after CON-1069 since we won't be building
+    //  the conclave-build image anymore.
+    fun buildInDocker(buildInDocker: Property<Boolean>): Boolean {
+        return !OperatingSystem.current().isLinux || buildInDocker.get()
     }
 
     /**
@@ -69,22 +91,19 @@ open class LinuxExec @Inject constructor(objects: ObjectFactory) : ConclaveTask(
      * that lives in the project folder. The temporary directory and all files contained within
      * are deleted when cleanPreparedFiles() is called.
      */
-    fun prepareFile(file: File): File {
-        return when (buildInDocker.get()) {
-            false -> file
-            true -> {
-                val tmp = File("${baseDirectory.get()}/.linuxexec")
-                tmp.mkdir()
-                val newFile = File.createTempFile(file.nameWithoutExtension, file.extension, tmp)
-                // The source file may not exist if this is an output file. Let the actual command being
-                // invoked handle any problems with missing/incorrect files
-                try {
-                    Files.copy(file.toPath(), newFile.toPath(), REPLACE_EXISTING)
-                } catch (e: IOException) {
-                }
-                newFile
-            }
+    fun prepareFile(file: Path): Path {
+        // Use the file as is if we're not using Docker
+        if (!buildInDocker(buildInDocker)) return file
+
+        val tmp = Paths.get(baseDirectory.get(), ".linuxexec").createDirectories()
+        val newFile = Files.createTempFile(tmp, file.nameWithoutExtension, file.extension)
+        // The source file may not exist if this is an output file. Let the actual command being
+        // invoked handle any problems with missing/incorrect files
+        if (file.exists()) {
+            Files.copy(file, newFile, REPLACE_EXISTING)
+
         }
+        return newFile
     }
 
     /**
@@ -92,7 +111,7 @@ open class LinuxExec @Inject constructor(objects: ObjectFactory) : ConclaveTask(
      * by a call to prepareFile().
      */
     fun cleanPreparedFiles() {
-        if (buildInDocker.get()) {
+        if (buildInDocker(buildInDocker)) {
             this.project.delete(File("${baseDirectory.get()}/.linuxexec"))
         }
     }
@@ -100,10 +119,9 @@ open class LinuxExec @Inject constructor(objects: ObjectFactory) : ConclaveTask(
     /** Returns the ERROR output of the command only, in the returned list. */
     fun exec(params: List<String>): List<String>? {
         val errorOut = ByteArrayOutputStream()
-        val args: List<String> = if (buildInDocker.get()) getDockerRunArgs(params) else params
 
         val result = commandLine(
-            args,
+            command = if (buildInDocker(buildInDocker)) getDockerRunArgs(params) else params,
             commandLineConfig = CommandLineConfig(ignoreExitValue = true, errorOutputStream = errorOut)
         )
 
@@ -119,11 +137,6 @@ open class LinuxExec @Inject constructor(objects: ObjectFactory) : ConclaveTask(
         }
         result.assertNormalExitValue()
         return null
-    }
-
-    /** Returns the output of the command executed in the container. */
-    fun execWithOutput(params: List<String>): String {
-        return commandWithOutput(*getDockerRunArgs(params).toTypedArray())
     }
 
     fun throwOutOfMemoryException(): Nothing = throw GradleException(

--- a/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/LinuxExec.kt
+++ b/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/LinuxExec.kt
@@ -62,7 +62,7 @@ open class LinuxExec @Inject constructor(objects: ObjectFactory) : ConclaveTask(
                 } else {
                     "Conclave requires Docker to be installed when building enclaves on non-Linux platforms. Please " +
                             "install Docker and rerun your build. See " +
-                            "https://docs.conclave.net/tutorial.html#setting-up-your-machine and " +
+                            "https://docs.conclave.net/running-hello-world.html#prerequisites and " +
                             "https://docs.conclave.net/writing-hello-world.html#configure-the-enclave-module for " +
                             "more information."
                 }

--- a/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/LinuxExec.kt
+++ b/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/LinuxExec.kt
@@ -1,6 +1,6 @@
 package com.r3.conclave.plugin.enclave.gradle
 
-import com.r3.conclave.plugin.enclave.gradle.GradleEnclavePlugin.Companion.retrievePackageVersionFromManifest
+import com.r3.conclave.plugin.enclave.gradle.GradleEnclavePlugin.Companion.getManifestAttribute
 import com.r3.conclave.utilities.internal.copyResource
 import org.gradle.api.GradleException
 import org.gradle.api.model.ObjectFactory
@@ -14,15 +14,11 @@ import java.nio.file.Path
 import java.nio.file.Paths
 import java.nio.file.StandardCopyOption.REPLACE_EXISTING
 import javax.inject.Inject
-import kotlin.io.path.createDirectories
-import kotlin.io.path.exists
-import kotlin.io.path.extension
-import kotlin.io.path.nameWithoutExtension
+import kotlin.io.path.*
 
 open class LinuxExec @Inject constructor(objects: ObjectFactory) : ConclaveTask() {
-
     companion object {
-        private val JEP_VERSION = retrievePackageVersionFromManifest("Jep-Version")
+        private val JEP_VERSION = getManifestAttribute("Jep-Version")
     }
 
     @get:Input
@@ -100,8 +96,7 @@ open class LinuxExec @Inject constructor(objects: ObjectFactory) : ConclaveTask(
         // The source file may not exist if this is an output file. Let the actual command being
         // invoked handle any problems with missing/incorrect files
         if (file.exists()) {
-            Files.copy(file, newFile, REPLACE_EXISTING)
-
+            file.copyTo(newFile, REPLACE_EXISTING)
         }
         return newFile
     }

--- a/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/SignEnclave.kt
+++ b/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/SignEnclave.kt
@@ -34,16 +34,16 @@ open class SignEnclave @Inject constructor(
     val buildInDocker: Property<Boolean> = objects.property(Boolean::class.java)
 
     override fun action() {
-        if (buildInDocker.get()) {
+        if (linuxExec.buildInDocker(buildInDocker)) {
             try {
                 // The input key file may not live in a directory accessible by docker.
                 // Prepare the file so docker can access it if necessary.
-                val keyFile = linuxExec.prepareFile(inputKey.asFile.get())
+                val keyFile = linuxExec.prepareFile(inputKey.asFile.get().toPath())
 
                 linuxExec.exec(
                     listOf<String>(
                         plugin.signToolPath().absolutePathString(), "sign",
-                        "-key", keyFile.absolutePath,
+                        "-key", keyFile.absolutePathString(),
                         "-enclave", inputEnclave.asFile.get().absolutePath,
                         "-out", outputSignedEnclave.asFile.get().absolutePath,
                         "-config", inputEnclaveConfig.asFile.get().absolutePath


### PR DESCRIPTION
https://github.com/R3Conclave/conclave-core-sdk/pull/101 accidently made building on MacOS and Windows conditional on the new `buildInDocker` flag. This is not correct as Docker is always required for these environments.