### PR TITLE
Passing the Conclave GraalVM version into the plugin jar manifest

### DIFF
--- a/plugin-enclave-gradle/build.gradle
+++ b/plugin-enclave-gradle/build.gradle
@@ -160,8 +160,9 @@ processResources {
 
 jar {
     manifest {
-        // This is used in the plugin to add implicit dependencies of the right version.
-        attributes("Conclave-Version": rootProject.version.toString(),
-                   "Jep-Version": jep_version.toString())
+        attributes(
+                "Conclave-GraalVM-Version": conclave_graal_version.toString(),
+                "Jep-Version": jep_version.toString()
+        )
     }
 }

--- a/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/GradleEnclavePlugin.kt
+++ b/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/GradleEnclavePlugin.kt
@@ -39,11 +39,8 @@ import kotlin.io.path.*
 
 class GradleEnclavePlugin @Inject constructor(private val layout: ProjectLayout) : Plugin<Project> {
     companion object {
-        private val CONCLAVE_SDK_VERSION = getManifestAttribute("Conclave-Version")
-
-        // Rather than appending CONCLAVE_SDK_VERSION here, we hard code it so the SDK and conclave-graalvm
-        // versions can go out of sync.
-        private const val CONCLAVE_GRAALVM_VERSION = "22.0.0.2-1.4-SNAPSHOT"
+        private val CONCLAVE_SDK_VERSION = getManifestAttribute("Conclave-Release-Version")
+        private val CONCLAVE_GRAALVM_VERSION = getManifestAttribute("Conclave-GraalVM-Version")
 
         fun getManifestAttribute(name: String): String {
             // Scan all MANIFEST.MF files in the plugin's classpath and find the given manifest attribute.

--- a/versions.gradle
+++ b/versions.gradle
@@ -1,6 +1,7 @@
 ext {
     conclave_version = '1.4-SNAPSHOT'
-    // Also update GradleEnclavePlugin.CONCLAVE_GRAALVM_VERSION
+    // Rather than appending $conclave_version here, we hard code it so the SDK and conclave-graalvm
+    // versions can go out of sync.
     conclave_graal_version = '22.0.0.2-1.4-SNAPSHOT'
     kds_version = '0.3-SNAPSHOT'
     kotlin_version = '1.7.22'


### PR DESCRIPTION
This avoids the need to duplicate the version string twice in the code base.

Also, updated the plugin to use the `Conclave-Release-Version` attribute value for the SDK version since it's set in all the jars, rather than having a duplicate entry under `Conclave-Version`.