### PR TITLE
CON-1255: Mandate the Gramine integration tests for PRs

### DIFF
--- a/conclave-host/src/main/kotlin/com/r3/conclave/host/internal/gramine/GramineEnclaveHandle.kt
+++ b/conclave-host/src/main/kotlin/com/r3/conclave/host/internal/gramine/GramineEnclaveHandle.kt
@@ -65,6 +65,7 @@ class GramineEnclaveHandle(
         val command = mutableListOf(getGramineExecutable(enclaveMode))
         command += listOf(
             "java",
+            "-XX:-UseCompressedClassPointers",
             "-cp",
             GRAMINE_ENCLAVE_JAR,
             "com.r3.conclave.enclave.internal.GramineEntryPoint",

--- a/conclave-host/src/main/kotlin/com/r3/conclave/host/internal/gramine/GramineEnclaveHandle.kt
+++ b/conclave-host/src/main/kotlin/com/r3/conclave/host/internal/gramine/GramineEnclaveHandle.kt
@@ -65,7 +65,7 @@ class GramineEnclaveHandle(
         val command = mutableListOf(getGramineExecutable(enclaveMode))
         command += listOf(
             "java",
-            "-XX:-UseCompressedClassPointers",
+            "-XX:-UseCompressedClassPointers", // TODO CON-1165, we need to understand why this is needed
             "-cp",
             GRAMINE_ENCLAVE_JAR,
             "com.r3.conclave.enclave.internal.GramineEntryPoint",

--- a/integration-tests/general/mock-compatibility-tests/src/test/kotlin/com/r3/conclave/integrationtests/general/mockcompattests/MockEnclaveEnvironmentHardwareCompatibilityTest.kt
+++ b/integration-tests/general/mock-compatibility-tests/src/test/kotlin/com/r3/conclave/integrationtests/general/mockcompattests/MockEnclaveEnvironmentHardwareCompatibilityTest.kt
@@ -12,6 +12,7 @@ import com.r3.conclave.host.internal.InternalsKt.createMockHost
 import com.r3.conclave.host.internal.InternalsKt.createNonMockHost
 import com.r3.conclave.integrationtests.general.commontest.TestUtils
 import com.r3.conclave.integrationtests.general.commontest.TestUtils.debugOnlyTest
+import com.r3.conclave.integrationtests.general.commontest.TestUtils.graalvmOnlyTest
 import com.r3.conclave.integrationtests.general.threadsafeenclave.ThreadSafeEnclave
 import com.r3.conclave.integrationtests.general.threadsafeenclave.ThreadSafeEnclaveSameSigner
 import org.assertj.core.api.Assertions.assertThat
@@ -66,6 +67,7 @@ class MockEnclaveEnvironmentHardwareCompatibilityTest {
         @BeforeAll
         fun check() {
             debugOnlyTest()
+            graalvmOnlyTest() // CON-1269: Accessing SGX Key does not work in Gramine
         }
     }
 

--- a/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/CreatePostOfficeTests.kt
+++ b/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/CreatePostOfficeTests.kt
@@ -2,6 +2,7 @@ package com.r3.conclave.integrationtests.general.tests
 
 import com.r3.conclave.integrationtests.general.common.tasks.CreatePostOffice
 import com.r3.conclave.integrationtests.general.commontest.AbstractEnclaveActionTest
+import com.r3.conclave.integrationtests.general.commontest.TestUtils.graalvmOnlyTest
 import org.assertj.core.api.Assertions.assertThatIllegalStateException
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -10,6 +11,7 @@ class CreatePostOfficeTests : AbstractEnclaveActionTest() {
     @ParameterizedTest
     @ValueSource(strings = ["PostOffice.create()", "EnclaveInstanceInfo.createPostOffice()"])
     fun `cannot create PostOffice directly when inside enclave`(source: String) {
+        graalvmOnlyTest() // CON-1271: Test creating PostOffice in the enclave fails in Gramine
         assertThatIllegalStateException()
             .isThrownBy { callEnclave(CreatePostOffice(source)) }
             .withMessage("Use one of the Enclave.postOffice() methods for getting a PostOffice instance when inside an enclave.")

--- a/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/DefaultEnclaveTests.kt
+++ b/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/DefaultEnclaveTests.kt
@@ -6,6 +6,7 @@ import com.r3.conclave.integrationtests.general.common.tasks.EchoWithCallback
 import com.r3.conclave.integrationtests.general.common.tasks.PutPersistentMap
 import com.r3.conclave.integrationtests.general.common.threadWithFuture
 import com.r3.conclave.integrationtests.general.commontest.AbstractEnclaveActionTest
+import com.r3.conclave.integrationtests.general.commontest.TestUtils.graalvmOnlyTest
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -62,6 +63,7 @@ class DefaultEnclaveTests : AbstractEnclaveActionTest() {
 
     @Test
     fun `destroy in OCALL`() {
+        graalvmOnlyTest() // CON-1262: Make sure EnclaveHost.close() cannot be called inside a callback
         val echo = EchoWithCallback(byteArrayOf())
         var called = false
         assertThatThrownBy {

--- a/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/EnclavePersistentMapTest.kt
+++ b/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/EnclavePersistentMapTest.kt
@@ -3,6 +3,7 @@ package com.r3.conclave.integrationtests.general.tests
 import com.r3.conclave.integrationtests.general.common.tasks.GetPersistentMap
 import com.r3.conclave.integrationtests.general.common.tasks.PutPersistentMap
 import com.r3.conclave.integrationtests.general.commontest.AbstractEnclaveActionTest
+import com.r3.conclave.integrationtests.general.commontest.TestUtils.graalvmOnlyTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junitpioneer.jupiter.cartesian.CartesianTest
 import org.junitpioneer.jupiter.cartesian.CartesianTest.Enum
@@ -18,6 +19,7 @@ class EnclavePersistentMapTest : AbstractEnclaveActionTest("com.r3.conclave.inte
         @Enum type: CallType,
         @Values(booleans = [false, true]) useKds: Boolean
     ) {
+        if (!useKds) graalvmOnlyTest() // CON-1264: Gramine: accessing filesystem and devices causes InvalidKeyException: Invalid AES key length: 0 bytes
         this.useKds = useKds
 
         val threads = 10

--- a/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/SealingTest.kt
+++ b/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/SealingTest.kt
@@ -7,6 +7,7 @@ import com.r3.conclave.integrationtests.general.common.tasks.SealData
 import com.r3.conclave.integrationtests.general.common.tasks.UnsealData
 import com.r3.conclave.integrationtests.general.commontest.AbstractEnclaveActionTest
 import com.r3.conclave.integrationtests.general.commontest.TestUtils
+import com.r3.conclave.integrationtests.general.commontest.TestUtils.graalvmOnlyTest
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.jupiter.params.ParameterizedTest
@@ -37,6 +38,7 @@ class SealingTest : AbstractEnclaveActionTest("com.r3.conclave.integrationtests.
     @ParameterizedTest
     @ValueSource(booleans = [ false, true ])
     fun `unseal with different enclave of same MRSIGNER`(withAD: Boolean) {
+        graalvmOnlyTest() // CON-1265: "javax.crypto.AEADBadTagException: Tag mismatch!" thrown when unsealing data in Gramine
         val sameMrsignerEnclave = enclaveHost("com.r3.conclave.integrationtests.general.threadsafeenclave.ThreadSafeEnclaveSameSigner")
         assertThat(enclaveHost().mrsigner).isEqualTo(sameMrsignerEnclave.mrsigner)
 
@@ -49,6 +51,7 @@ class SealingTest : AbstractEnclaveActionTest("com.r3.conclave.integrationtests.
     @ParameterizedTest
     @ValueSource(booleans = [ false, true ])
     fun `unseal with enclave of different MRSIGNER`(withAD: Boolean) {
+        graalvmOnlyTest() // CON-1265: "javax.crypto.AEADBadTagException: Tag mismatch!" thrown when unsealing data in Gramine
         val differentMrsignerEnclave = enclaveHost("com.r3.conclave.integrationtests.general.defaultenclave.DefaultEnclave")
         assertThat(enclaveHost().mrsigner).isNotEqualTo(differentMrsignerEnclave.mrsigner)
 

--- a/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/ThreadSafeEnclaveTests.kt
+++ b/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/ThreadSafeEnclaveTests.kt
@@ -1,13 +1,17 @@
 package com.r3.conclave.integrationtests.general.tests
 
+import com.r3.conclave.common.EnclaveMode
 import com.r3.conclave.integrationtests.general.common.tasks.*
 import com.r3.conclave.integrationtests.general.common.threadWithFuture
 import com.r3.conclave.integrationtests.general.common.toByteArray
 import com.r3.conclave.integrationtests.general.common.toInt
 import com.r3.conclave.integrationtests.general.commontest.AbstractEnclaveActionTest
+import com.r3.conclave.integrationtests.general.commontest.TestUtils
 import com.r3.conclave.integrationtests.general.commontest.TestUtils.graalvmOnlyTest
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Assumptions
+import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Test
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicInteger
@@ -89,6 +93,12 @@ class ThreadSafeEnclaveTests : AbstractEnclaveActionTest("com.r3.conclave.integr
 
     @Test
     fun `threading inside enclave`() {
+        //  For Gramine, we want this test to run only in SIMULATION mode
+        // CON-1270: Requesting too many threads is failing in Gramine
+        if (TestUtils.RuntimeType.GRAMINE.name == System.getProperty("runtimeType").uppercase()) {
+            assumeTrue(EnclaveMode.SIMULATION.name == System.getProperty("enclaveMode").uppercase())
+        }
+
         val n = 38 // <= thread safe enclave maxThreads (40)
         val result = callEnclave(TooManyThreadsRequestedAction(n))
         assertThat(result).isEqualTo((n * (n + 1)) / 2)

--- a/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/ThreadSafeEnclaveTests.kt
+++ b/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/ThreadSafeEnclaveTests.kt
@@ -1,6 +1,5 @@
 package com.r3.conclave.integrationtests.general.tests
 
-import com.r3.conclave.common.EnclaveMode
 import com.r3.conclave.integrationtests.general.common.tasks.*
 import com.r3.conclave.integrationtests.general.common.threadWithFuture
 import com.r3.conclave.integrationtests.general.common.toByteArray
@@ -8,10 +7,9 @@ import com.r3.conclave.integrationtests.general.common.toInt
 import com.r3.conclave.integrationtests.general.commontest.AbstractEnclaveActionTest
 import com.r3.conclave.integrationtests.general.commontest.TestUtils
 import com.r3.conclave.integrationtests.general.commontest.TestUtils.graalvmOnlyTest
+import com.r3.conclave.integrationtests.general.commontest.TestUtils.simulationOnlyTest
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.junit.jupiter.api.Assumptions
-import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Test
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicInteger
@@ -95,8 +93,8 @@ class ThreadSafeEnclaveTests : AbstractEnclaveActionTest("com.r3.conclave.integr
     fun `threading inside enclave`() {
         //  For Gramine, we want this test to run only in SIMULATION mode
         // CON-1270: Requesting too many threads is failing in Gramine
-        if (TestUtils.RuntimeType.GRAMINE.name == System.getProperty("runtimeType").uppercase()) {
-            assumeTrue(EnclaveMode.SIMULATION.name == System.getProperty("enclaveMode").uppercase())
+        if (TestUtils.RuntimeType.GRAMINE.name == TestUtils.runtimeType.name) {
+            simulationOnlyTest()
         }
 
         val n = 38 // <= thread safe enclave maxThreads (40)

--- a/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/ThreadSafeEnclaveTests.kt
+++ b/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/ThreadSafeEnclaveTests.kt
@@ -5,9 +5,9 @@ import com.r3.conclave.integrationtests.general.common.threadWithFuture
 import com.r3.conclave.integrationtests.general.common.toByteArray
 import com.r3.conclave.integrationtests.general.common.toInt
 import com.r3.conclave.integrationtests.general.commontest.AbstractEnclaveActionTest
+import com.r3.conclave.integrationtests.general.commontest.TestUtils.graalvmOnlyTest
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicInteger
@@ -96,6 +96,8 @@ class ThreadSafeEnclaveTests : AbstractEnclaveActionTest("com.r3.conclave.integr
 
     @Test
     fun `exception is thrown if too many threads are requested`() {
+        graalvmOnlyTest() // CON-1270: Requesting too many threads is failing in Gramine
+
         // This test hangs when tearing down the enclave, so we disable teardown here.
         // TODO: CON-1244 Figure out why this test hangs, then remove this teardown logic.
         doEnclaveTeardown = false

--- a/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/ThreadSafeEnclaveTests.kt
+++ b/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/ThreadSafeEnclaveTests.kt
@@ -93,7 +93,7 @@ class ThreadSafeEnclaveTests : AbstractEnclaveActionTest("com.r3.conclave.integr
     fun `threading inside enclave`() {
         //  For Gramine, we want this test to run only in SIMULATION mode
         // CON-1270: Requesting too many threads is failing in Gramine
-        if (TestUtils.RuntimeType.GRAMINE.name == TestUtils.runtimeType.name) {
+        if (TestUtils.runtimeType == TestUtils.RuntimeType.GRAMINE) {
             simulationOnlyTest()
         }
 

--- a/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/ThreadSafeEnclaveTests.kt
+++ b/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/ThreadSafeEnclaveTests.kt
@@ -106,7 +106,7 @@ class ThreadSafeEnclaveTests : AbstractEnclaveActionTest("com.r3.conclave.integr
 
     @Test
     fun `exception is thrown if too many threads are requested`() {
-        graalvmOnlyTest() // CON-1270: Requesting too many threads is failing in Gramine
+        graalvmOnlyTest() // CON-1270: Requesting too many threads test is failing in Gramine
 
         // This test hangs when tearing down the enclave, so we disable teardown here.
         // TODO: CON-1244 Figure out why this test hangs, then remove this teardown logic.

--- a/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/filesystem/BufferedInputStreamTest.kt
+++ b/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/filesystem/BufferedInputStreamTest.kt
@@ -3,6 +3,7 @@ package com.r3.conclave.integrationtests.general.tests.filesystem
 import com.r3.conclave.integrationtests.general.common.tasks.CloseInputStream
 import com.r3.conclave.integrationtests.general.common.tasks.NewBufferedFileInputStream
 import com.r3.conclave.integrationtests.general.common.tasks.ReadBytesFromInputStream
+import com.r3.conclave.integrationtests.general.commontest.TestUtils.graalvmOnlyTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -31,6 +32,7 @@ class BufferedInputStreamTest : FileSystemEnclaveTest() {
     @ParameterizedTest
     @ValueSource(strings = ["/buffered-input-stream.data", "/tmp/buffered-input-stream.data"])
     fun readToBuffer(path: String) {
+        graalvmOnlyTest() // CON-1264: Gramine: accessing filesystem and devices causes InvalidKeyException: Invalid AES key length: 0 bytes
         val data = ByteArray(10 * 1024 * 1024) { i -> i.toByte() }
         filesWrite(path, data)
 

--- a/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/filesystem/DefaultFileSystemTest.kt
+++ b/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/filesystem/DefaultFileSystemTest.kt
@@ -1,6 +1,7 @@
 package com.r3.conclave.integrationtests.general.tests.filesystem
 
 import com.r3.conclave.integrationtests.general.common.tasks.ReadAndWriteFilesToDefaultFileSystem
+import com.r3.conclave.integrationtests.general.commontest.TestUtils.graalvmOnlyTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -9,6 +10,7 @@ class DefaultFileSystemTest : FileSystemEnclaveTest() {
 
     @Test
     fun `read and write files to default filesystem`() {
+        graalvmOnlyTest() // CON-1264: Gramine: accessing filesystem and devices causes InvalidKeyException: Invalid AES key length: 0 bytes
         val texts = callEnclave(ReadAndWriteFilesToDefaultFileSystem(fileNumber))
         assertThat(texts).isEqualTo((0 until fileNumber).map { "Dummy text from file $it" })
     }

--- a/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/filesystem/EnclaveRestartFileSystemTest.kt
+++ b/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/filesystem/EnclaveRestartFileSystemTest.kt
@@ -1,9 +1,10 @@
 package com.r3.conclave.integrationtests.general.tests.filesystem
 
-import com.r3.conclave.host.EnclaveLoadException
 import com.r3.conclave.common.EnclaveException
+import com.r3.conclave.host.EnclaveLoadException
 import com.r3.conclave.integrationtests.general.common.tasks.ReadAndWriteFiles
 import com.r3.conclave.integrationtests.general.common.tasks.ReadFiles
+import com.r3.conclave.integrationtests.general.commontest.TestUtils.graalvmOnlyTest
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
@@ -15,6 +16,7 @@ class EnclaveRestartFileSystemTest : FileSystemEnclaveTest() {
 
     @Test
     fun `cannot read previously saved files after enclave restarts when using in-memory filesystem`() {
+        graalvmOnlyTest() // CON-1264: Gramine: accessing filesystem and devices causes InvalidKeyException: Invalid AES key length: 0 bytes
         //  Files that have been written in the in-memory filesystems are not
         //    present anymore after a restart.
         //  Files like /tmp/test_file_0.txt are written in ReadAndWriteFiles, but then they are not found again
@@ -30,6 +32,7 @@ class EnclaveRestartFileSystemTest : FileSystemEnclaveTest() {
     @ParameterizedTest
     @ValueSource(booleans = [false, true])
     fun `can read files after enclave restarts from a restarted persistent filesystem `(useKds: Boolean) {
+        graalvmOnlyTest() // CON-1259: Make sure using enclave file system with Gramine produces graceful exception
         this.useKds = useKds
 
         val reply = restartEnclaveBetweenWriteAndRead("")
@@ -42,6 +45,7 @@ class EnclaveRestartFileSystemTest : FileSystemEnclaveTest() {
 
     @Test
     fun `an enclave with persistent disk size bigger than 0 but without host path`() {
+        graalvmOnlyTest() // CON-1259: Make sure using enclave file system with Gramine produces graceful exception
         fileSystemFileTempDir = null
         assertThatThrownBy {
             callEnclave(ReadAndWriteFiles(numThreads, ""))

--- a/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/filesystem/FileInputStreamTest.kt
+++ b/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/filesystem/FileInputStreamTest.kt
@@ -1,6 +1,7 @@
 package com.r3.conclave.integrationtests.general.tests.filesystem
 
 import com.r3.conclave.integrationtests.general.common.tasks.*
+import com.r3.conclave.integrationtests.general.commontest.TestUtils.graalvmOnlyTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
@@ -58,6 +59,7 @@ class FileInputStreamTest : FileSystemEnclaveTest() {
         "/tmp/file.data, false"
     )
     fun writeReadDeleteFiles(path: String, nioApi: Boolean) {
+        graalvmOnlyTest() // CON-1264: Gramine: accessing filesystem and devices causes InvalidKeyException: Invalid AES key length: 0 bytes
         val smallFileData = byteArrayOf(1, 2, 3)
 
         // Write the file and create a FileInputStream
@@ -91,6 +93,7 @@ class FileInputStreamTest : FileSystemEnclaveTest() {
     @ParameterizedTest
     @ValueSource(strings = ["/dev/random", "/dev/urandom"])
     fun readRandomDevices(device: String) {
+        graalvmOnlyTest() // CON-1264: Gramine: accessing filesystem and devices causes InvalidKeyException: Invalid AES key length: 0 bytes
         Handler(uid.getAndIncrement(), device).use { fis ->
             fis.readSingleByte()
         }

--- a/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/filesystem/FileOutputStreamTest.kt
+++ b/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/filesystem/FileOutputStreamTest.kt
@@ -1,6 +1,7 @@
 package com.r3.conclave.integrationtests.general.tests.filesystem
 
 import com.r3.conclave.integrationtests.general.common.tasks.*
+import com.r3.conclave.integrationtests.general.commontest.TestUtils.graalvmOnlyTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
@@ -40,6 +41,7 @@ class FileOutputStreamTest : FileSystemEnclaveTest() {
         "/tmp/fos.data, false"
     )
     fun fileOutputStreamWriteRead(path: String, nioApi: Boolean) {
+        graalvmOnlyTest() // CON-1264: Gramine: accessing filesystem and devices causes InvalidKeyException: Invalid AES key length: 0 bytes
         val fileData = byteArrayOf(1, 2, 3, 4)
         val reversedFileData = fileData.reversed().toByteArray()
         // Create a FileOutputStream and write the content byte by byte
@@ -79,6 +81,7 @@ class FileOutputStreamTest : FileSystemEnclaveTest() {
         "/tmp/fos-append.data, false"
     )
     fun fileOutputStreamAppendWrite(path: String, nioApi: Boolean) {
+        graalvmOnlyTest() // CON-1264: Gramine: accessing filesystem and devices causes InvalidKeyException: Invalid AES key length: 0 bytes
         val fileData = byteArrayOf(10, 20, 30, 40)
         val appendData = byteArrayOf(50, 60, 70)
         // Create a FileOutputStream with append mode set

--- a/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/filesystem/FileSystemInputStreamTest.kt
+++ b/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/filesystem/FileSystemInputStreamTest.kt
@@ -1,12 +1,13 @@
 package com.r3.conclave.integrationtests.general.tests.filesystem
 
+import com.r3.conclave.common.EnclaveException
 import com.r3.conclave.integrationtests.general.common.tasks.*
+import com.r3.conclave.integrationtests.general.commontest.TestUtils.graalvmOnlyTest
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import java.io.IOException
-import com.r3.conclave.common.EnclaveException
 
 class FileSystemInputStreamTest : FileSystemEnclaveTest() {
 
@@ -49,6 +50,7 @@ class FileSystemInputStreamTest : FileSystemEnclaveTest() {
         "/tmp/filesystem.data, false"
     )
     fun fileSystemStreamReadResetReadBytes(path: String, nioApi: Boolean) {
+        graalvmOnlyTest() // CON-1264: Gramine: accessing filesystem and devices causes InvalidKeyException: Invalid AES key length: 0 bytes
         val smallFileData = byteArrayOf(1, 2, 3)
         filesWrite(path, smallFileData)
         // Create an InputStream
@@ -71,6 +73,7 @@ class FileSystemInputStreamTest : FileSystemEnclaveTest() {
         "/tmp/filesystem-reset.data, false"
     )
     fun fileSystemResetThrowsException(path: String, nioApi: Boolean) {
+        graalvmOnlyTest() // CON-1264: Gramine: accessing filesystem and devices causes InvalidKeyException: Invalid AES key length: 0 bytes
         val smallFileData = byteArrayOf(1, 2, 3)
         filesWrite(path, smallFileData)
         // Create an InputStream

--- a/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/filesystem/FilesTest.kt
+++ b/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/filesystem/FilesTest.kt
@@ -1,12 +1,11 @@
 package com.r3.conclave.integrationtests.general.tests.filesystem
 
-import com.r3.conclave.common.EnclaveMode.SIMULATION
 import com.r3.conclave.host.EnclaveLoadException
 import com.r3.conclave.integrationtests.general.common.tasks.*
 import com.r3.conclave.integrationtests.general.commontest.TestUtils.graalvmOnlyTest
+import com.r3.conclave.integrationtests.general.commontest.TestUtils.simulationOnlyTest
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.params.ParameterizedTest
@@ -187,7 +186,7 @@ class FilesTest : FileSystemEnclaveTest() {
         graalvmOnlyTest() // CON-1259: Make sure using enclave file system with Gramine produces graceful exception
 
         //  We want this test to run only in SIMULATION mode
-        assumeTrue(SIMULATION.name == System.getProperty("enclaveMode").uppercase())
+        simulationOnlyTest()
 
         copyCorruptedFileSystem()
 

--- a/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/filesystem/FilesTest.kt
+++ b/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/filesystem/FilesTest.kt
@@ -3,6 +3,7 @@ package com.r3.conclave.integrationtests.general.tests.filesystem
 import com.r3.conclave.common.EnclaveMode.SIMULATION
 import com.r3.conclave.host.EnclaveLoadException
 import com.r3.conclave.integrationtests.general.common.tasks.*
+import com.r3.conclave.integrationtests.general.commontest.TestUtils.graalvmOnlyTest
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Assumptions.assumeTrue
@@ -53,6 +54,7 @@ class FilesTest : FileSystemEnclaveTest() {
         "/tmp/parent-dir, false"
     )
     fun createDeleteSingleDirectory(parent: String, nioApi: Boolean) {
+        graalvmOnlyTest() // CON-1264: Gramine: accessing filesystem and devices causes InvalidKeyException: Invalid AES key length: 0 bytes
         val child = "$parent/child-dir"
         // Ensure creating a directory without creating its parent first fails with the expected exception
         createDirectoryWithoutParent(child)
@@ -73,6 +75,7 @@ class FilesTest : FileSystemEnclaveTest() {
         "/tmp/multiple-dir/conclave-test, false"
     )
     fun createDeleteMultipleDirectories(dir: String, nioApi: Boolean) {
+        graalvmOnlyTest() // CON-1264: Gramine: accessing filesystem and devices causes InvalidKeyException: Invalid AES key length: 0 bytes
         val smallFileData = byteArrayOf(3, 2, 1)
         val path = "$dir/file.data"
         // Create parent and child directories at once
@@ -96,6 +99,7 @@ class FilesTest : FileSystemEnclaveTest() {
         "/tmp/parent-dir",
     )
     fun createDeleteNestedDirectories(parent: String) {
+        graalvmOnlyTest() // CON-1264: Gramine: accessing filesystem and devices causes InvalidKeyException: Invalid AES key length: 0 bytes
         val path = "$parent/child-dir/grandchild-dir"
         callEnclave(WalkAndDelete(path))
         assertThat(callEnclave(FilesExists(path))).isFalse
@@ -107,6 +111,7 @@ class FilesTest : FileSystemEnclaveTest() {
         "/tmp/parent-dir",
     )
     fun listFilesMultipleTimes(dir: String) {
+        graalvmOnlyTest() // CON-1264: Gramine: accessing filesystem and devices causes InvalidKeyException: Invalid AES key length: 0 bytes
         val smallFileData = byteArrayOf(3, 2, 1)
         val path1 = "$dir/file1.data"
         val path2 = "$dir/file2.data"
@@ -130,6 +135,7 @@ class FilesTest : FileSystemEnclaveTest() {
         "/tmp/readBytes.data, false"
     )
     fun readBytes(path: String, nioApi: Boolean) {
+        graalvmOnlyTest() // CON-1264: Gramine: accessing filesystem and devices causes InvalidKeyException: Invalid AES key length: 0 bytes
         val smallFileData = byteArrayOf(1, 2, 3, 4)
         filesWrite(path, smallFileData)
         // Test Files.readAllBytes
@@ -146,6 +152,7 @@ class FilesTest : FileSystemEnclaveTest() {
         "/tmp/file-size.data, false"
     )
     fun fileSize(path: String, nioApi: Boolean) {
+        graalvmOnlyTest() // CON-1264: Gramine: accessing filesystem and devices causes InvalidKeyException: Invalid AES key length: 0 bytes
         val smallFileData = byteArrayOf(4, 3, 2, 1)
         filesWrite(path, smallFileData)
         // Test Files.size
@@ -156,6 +163,7 @@ class FilesTest : FileSystemEnclaveTest() {
     @ParameterizedTest
     @ValueSource(strings = ["/dev/random", "/dev/urandom"])
     fun readRandomDevice(device: String) {
+        graalvmOnlyTest() // CON-1264: Gramine: accessing filesystem and devices causes InvalidKeyException: Invalid AES key length: 0 bytes
         Handler(uid.getAndIncrement(), device).use {
             it.readSingleByte()
         }
@@ -169,6 +177,7 @@ class FilesTest : FileSystemEnclaveTest() {
         "/tmp/fos-delete-on-close.data, false"
     )
     fun outputStreamDeleteOnClose(path: String, nioApi: Boolean) {
+        graalvmOnlyTest() // CON-1264: Gramine: accessing filesystem and devices causes InvalidKeyException: Invalid AES key length: 0 bytes
         FilesNewOutputStreamHandler(uid.getAndIncrement(), path).close()
         fileInputStreamNonExistingFile(path, nioApi)
     }
@@ -194,6 +203,7 @@ class FilesTest : FileSystemEnclaveTest() {
         "/persistent-fs-dir/,/tmp/in-memory-fs-dir"
     )
     fun `ensure moving directories between filesystems does not throw an error - empty directory`(src: String, dst: String) {
+        graalvmOnlyTest() // CON-1264: Gramine: accessing filesystem and devices causes InvalidKeyException: Invalid AES key length: 0 bytes
         createDirectory(src)
 
         assertDoesNotThrow {
@@ -210,6 +220,7 @@ class FilesTest : FileSystemEnclaveTest() {
         "/persistent-fs-dir/,/tmp/in-memory-fs-dir"
     )
     fun `ensure moving directories between filesystems throws an error - not an empty directory`(src: String, dst: String) {
+        graalvmOnlyTest() // CON-1264: Gramine: accessing filesystem and devices causes InvalidKeyException: Invalid AES key length: 0 bytes
         createDirectory(src)
         createDirectory("$src/a")
 

--- a/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/filesystem/FilesTest.kt
+++ b/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/filesystem/FilesTest.kt
@@ -184,6 +184,8 @@ class FilesTest : FileSystemEnclaveTest() {
 
     @Test
     fun `an enclave with corrupted persistent filesystem fails`() {
+        graalvmOnlyTest() // CON-1259: Make sure using enclave file system with Gramine produces graceful exception
+
         //  We want this test to run only in SIMULATION mode
         assumeTrue(SIMULATION.name == System.getProperty("enclaveMode").uppercase())
 

--- a/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/filesystem/MultiThreadedFileSystemTest.kt
+++ b/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/filesystem/MultiThreadedFileSystemTest.kt
@@ -3,6 +3,7 @@ package com.r3.conclave.integrationtests.general.tests.filesystem
 import com.r3.conclave.integrationtests.general.common.tasks.RandomAccessFileConcurrentWrites
 import com.r3.conclave.integrationtests.general.common.tasks.ReadAndWriteFiles
 import com.r3.conclave.integrationtests.general.common.tasks.WriteFilesConcurrently
+import com.r3.conclave.integrationtests.general.commontest.TestUtils.graalvmOnlyTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -22,6 +23,7 @@ class MultiThreadedFileSystemTest : FileSystemEnclaveTest() {
     @ParameterizedTest
     @ValueSource(strings = ["", "/tmp"])
     fun readWriteManyFiles(path: String) {
+        graalvmOnlyTest() // CON-1264: Gramine: accessing filesystem and devices causes InvalidKeyException: Invalid AES key length: 0 bytes
         val reply = callEnclave(ReadAndWriteFiles(THREADS, path))
         verifyResponse(reply)
     }
@@ -29,6 +31,7 @@ class MultiThreadedFileSystemTest : FileSystemEnclaveTest() {
     @ParameterizedTest
     @ValueSource(strings = ["", "/tmp"])
     fun multiThreadReadWriteManyFiles(path: String) {
+        graalvmOnlyTest() // CON-1264: Gramine: accessing filesystem and devices causes InvalidKeyException: Invalid AES key length: 0 bytes
         val reply = callEnclave(WriteFilesConcurrently(THREADS, path))
         verifyResponse(reply)
     }
@@ -36,6 +39,7 @@ class MultiThreadedFileSystemTest : FileSystemEnclaveTest() {
     @ParameterizedTest
     @ValueSource(strings = ["", "/tmp"])
     fun multiThreadReadWriteSingleFile(path: String) {
+        graalvmOnlyTest() // CON-1264: Gramine: accessing filesystem and devices causes InvalidKeyException: Invalid AES key length: 0 bytes
         val replyText = callEnclave(RandomAccessFileConcurrentWrites(THREADS, path))
         val count = replyText.split("Dummy text from file").size - 1
         assertThat(count).isEqualTo(THREADS)

--- a/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/filesystem/PathsTest.kt
+++ b/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/filesystem/PathsTest.kt
@@ -1,6 +1,7 @@
 package com.r3.conclave.integrationtests.general.tests.filesystem
 
 import com.r3.conclave.integrationtests.general.common.tasks.PathsGet
+import com.r3.conclave.integrationtests.general.commontest.TestUtils.graalvmOnlyTest
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 
@@ -14,6 +15,7 @@ class PathsTest : FileSystemEnclaveTest() {
         "/tmp/paths.data, false"
     )
     fun pathsGet(path: String, nioApi: Boolean) {
+        graalvmOnlyTest() // CON-1264: Gramine: accessing filesystem and devices causes InvalidKeyException: Invalid AES key length: 0 bytes
         val fileData = byteArrayOf(1, 2, 3)
         filesWrite(path, fileData)
 
@@ -29,6 +31,7 @@ class PathsTest : FileSystemEnclaveTest() {
 
     )
     fun symlink(path: String, symlinkPath: String) {
+        graalvmOnlyTest() // CON-1264: Gramine: accessing filesystem and devices causes InvalidKeyException: Invalid AES key length: 0 bytes
         val fileData = byteArrayOf(1, 2, 3)
         filesWrite(path, fileData)
 
@@ -43,6 +46,7 @@ class PathsTest : FileSystemEnclaveTest() {
         "/tmp/paths.data, /paths.datalink"
     )
     fun link(path: String, symlinkPath: String) {
+        graalvmOnlyTest() // CON-1264: Gramine: accessing filesystem and devices causes InvalidKeyException: Invalid AES key length: 0 bytes
         val fileData = byteArrayOf(1, 2, 3)
         filesWrite(path, fileData)
 

--- a/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/filesystem/RenameTests.kt
+++ b/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/filesystem/RenameTests.kt
@@ -1,5 +1,6 @@
 package com.r3.conclave.integrationtests.general.tests.filesystem
 
+import com.r3.conclave.integrationtests.general.commontest.TestUtils.graalvmOnlyTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
@@ -16,6 +17,7 @@ class RenameTests : FileSystemEnclaveTest() {
         "/tmp/file1.data, /tmp/file2.data, false"
     )
     fun renameFiles(oldPath: String, newPath: String, nioApi: Boolean) {
+        graalvmOnlyTest() // CON-1264: Gramine: accessing filesystem and devices causes InvalidKeyException: Invalid AES key length: 0 bytes
         val testData = "Test data for a file to rename"
         filesWrite(oldPath, testData.toByteArray())
         renamePath(oldPath, newPath, nioApi)
@@ -29,6 +31,7 @@ class RenameTests : FileSystemEnclaveTest() {
         "/tmp/file1.data, /tmp/file1.data, false"
     )
     fun renameFilesToThemselves(oldPath: String, newPath: String, nioApi: Boolean) {
+        graalvmOnlyTest() // CON-1264: Gramine: accessing filesystem and devices causes InvalidKeyException: Invalid AES key length: 0 bytes
         val testData = "Test data for a file to rename"
         filesWrite(oldPath, testData.toByteArray())
         renameSamePath(oldPath, newPath, nioApi)
@@ -42,6 +45,7 @@ class RenameTests : FileSystemEnclaveTest() {
         "/tmp/file1.data, /tmp/testdir/file1.data, false"
     )
     fun renameFilesWithDir(oldPath: String, newPath: String, nioApi: Boolean) {
+        graalvmOnlyTest() // CON-1264: Gramine: accessing filesystem and devices causes InvalidKeyException: Invalid AES key length: 0 bytes
         val testData = "Test data for a file to rename"
         filesWrite(oldPath, testData.toByteArray())
         createDirectory(Paths.get(newPath).parent.toString())
@@ -56,6 +60,7 @@ class RenameTests : FileSystemEnclaveTest() {
         "/tmp/file1.data, /tmp/file2.data, false",
     )
     fun renameNonExistentFiles(oldPath: String, newPath: String, nioApi: Boolean) {
+        graalvmOnlyTest() // CON-1264: Gramine: accessing filesystem and devices causes InvalidKeyException: Invalid AES key length: 0 bytes
         renameNonExistentPath(oldPath, newPath, nioApi)
     }
 
@@ -67,6 +72,7 @@ class RenameTests : FileSystemEnclaveTest() {
         "/tmp/file1.data, /tmp/file2.data, false"
     )
     fun renameToExistentFiles(oldPath: String, newPath: String, nioApi: Boolean) {
+        graalvmOnlyTest() // CON-1264: Gramine: accessing filesystem and devices causes InvalidKeyException: Invalid AES key length: 0 bytes
         val testData1 = "Test data for a file to rename"
         val testData2 = "More data for a file to rename, bigger size than previous one"
         filesWrite(oldPath, testData1.toByteArray())
@@ -84,6 +90,7 @@ class RenameTests : FileSystemEnclaveTest() {
         "/tmp/emptydir, /tmp/emptydir2, false"
     )
     fun renameEmptyDirectories(oldPath: String, newPath: String, nioApi: Boolean) {
+        graalvmOnlyTest() // CON-1264: Gramine: accessing filesystem and devices causes InvalidKeyException: Invalid AES key length: 0 bytes
         createDirectory(oldPath)
         renamePath(oldPath, newPath, nioApi)
     }
@@ -96,6 +103,7 @@ class RenameTests : FileSystemEnclaveTest() {
         "/tmp/nonemptydir, /tmp/nonemptydir2, false"
     )
     fun renameNonEmptyDirectories(oldPath: String, newPath: String, nioApi: Boolean) {
+        graalvmOnlyTest() // CON-1264: Gramine: accessing filesystem and devices causes InvalidKeyException: Invalid AES key length: 0 bytes
         val testData = "Test data for a file to rename"
         createDirectory(oldPath)
         filesWrite("$oldPath/test_file.txt", testData.toByteArray())
@@ -110,6 +118,7 @@ class RenameTests : FileSystemEnclaveTest() {
         "/tmp/nonemptydir, /tmp/nonemptydir2, false"
     )
     fun renameToNonEmptyDirectories(oldPath: String, newPath: String, nioApi: Boolean) {
+        graalvmOnlyTest() // CON-1264: Gramine: accessing filesystem and devices causes InvalidKeyException: Invalid AES key length: 0 bytes
         val testData = "Test data for a file to rename"
         createDirectory(oldPath)
         filesWrite("$oldPath/test_file.txt", testData.toByteArray())
@@ -126,6 +135,7 @@ class RenameTests : FileSystemEnclaveTest() {
         "/tmp/nonemptydir, /tmp/emptydir2, false"
     )
     fun renameNestedDirectories(oldPath: String, newPath: String, nioApi: Boolean) {
+        graalvmOnlyTest() // CON-1264: Gramine: accessing filesystem and devices causes InvalidKeyException: Invalid AES key length: 0 bytes
         val testData1 = "Test data1 for a file to rename"
         val testData2 = "Test data2 for a file to rename"
         createDirectory(oldPath)
@@ -162,6 +172,7 @@ class RenameTests : FileSystemEnclaveTest() {
         "/tmp/file1.data, /file1.data, false"
     )
     fun renameAcrossFileSystems(oldPath: String, newPath: String, nioApi: Boolean) {
+        graalvmOnlyTest() // CON-1264: Gramine: accessing filesystem and devices causes InvalidKeyException: Invalid AES key length: 0 bytes
         val testData = "Test data for a file to rename"
         filesWrite(oldPath, testData.toByteArray())
         renamePathAcrossFileSystems(oldPath, newPath, nioApi)

--- a/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/filesystem/SeekableByteChannelTest.kt
+++ b/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/filesystem/SeekableByteChannelTest.kt
@@ -2,6 +2,7 @@ package com.r3.conclave.integrationtests.general.tests.filesystem
 
 import com.r3.conclave.integrationtests.general.common.tasks.CloseByteChannel
 import com.r3.conclave.integrationtests.general.common.tasks.NewDeleteOnCloseByteChannel
+import com.r3.conclave.integrationtests.general.commontest.TestUtils.graalvmOnlyTest
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 
@@ -25,6 +26,7 @@ class SeekableByteChannelTest : FileSystemEnclaveTest() {
         "/tmp/bytechannel-delete-on-close.data, false"
     )
     fun byteChannelDeleteOnClose(path: String, nioApi: Boolean) {
+        graalvmOnlyTest() // CON-1264: Gramine: accessing filesystem and devices causes InvalidKeyException: Invalid AES key length: 0 bytes
         Handler(uid.getAndIncrement(), path).close()
         fileInputStreamNonExistingFile(path, nioApi)
     }

--- a/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/filesystem/db/DatabaseEnclaveTest.kt
+++ b/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/filesystem/db/DatabaseEnclaveTest.kt
@@ -5,6 +5,7 @@ import com.r3.conclave.integrationtests.general.common.tasks.ExecuteSql
 import com.r3.conclave.integrationtests.general.common.tasks.SqlQuery
 import com.r3.conclave.integrationtests.general.commontest.TestUtils
 import com.r3.conclave.integrationtests.general.commontest.TestUtils.graalvmOnlyTest
+import com.r3.conclave.integrationtests.general.commontest.TestUtils.simulationOnlyTest
 import com.r3.conclave.integrationtests.general.tests.filesystem.FileSystemEnclaveTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assumptions.assumeTrue
@@ -24,8 +25,8 @@ class DatabaseEnclaveTest : FileSystemEnclaveTest("com.r3.conclave.integrationte
 
         //  For Gramine, we want this test to run only in SIMULATION mode
         // CON-1268: Gramine: cannot access database
-        if (TestUtils.RuntimeType.GRAMINE.name == System.getProperty("runtimeType").uppercase()) {
-            assumeTrue(EnclaveMode.SIMULATION.name == System.getProperty("enclaveMode").uppercase())
+        if (TestUtils.RuntimeType.GRAMINE.name == TestUtils.runtimeType.name) {
+            simulationOnlyTest()
         }
 
         this.useKds = useKds

--- a/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/filesystem/db/DatabaseEnclaveTest.kt
+++ b/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/filesystem/db/DatabaseEnclaveTest.kt
@@ -2,6 +2,7 @@ package com.r3.conclave.integrationtests.general.tests.filesystem.db
 
 import com.r3.conclave.integrationtests.general.common.tasks.ExecuteSql
 import com.r3.conclave.integrationtests.general.common.tasks.SqlQuery
+import com.r3.conclave.integrationtests.general.commontest.TestUtils.graalvmOnlyTest
 import com.r3.conclave.integrationtests.general.tests.filesystem.FileSystemEnclaveTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.params.ParameterizedTest
@@ -16,6 +17,7 @@ class DatabaseEnclaveTest : FileSystemEnclaveTest("com.r3.conclave.integrationte
         "true, true"
     )
     fun `sql inside enclave`(restartBetweenCmds: Boolean, useKds: Boolean) {
+        if (restartBetweenCmds) graalvmOnlyTest() // CON-1268: Gramine: cannot access database after restarting the enclave
         this.useKds = useKds
 
         callEnclave(ExecuteSql("""

--- a/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/filesystem/db/DatabaseEnclaveTest.kt
+++ b/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/filesystem/db/DatabaseEnclaveTest.kt
@@ -1,6 +1,5 @@
 package com.r3.conclave.integrationtests.general.tests.filesystem.db
 
-import com.r3.conclave.common.EnclaveMode
 import com.r3.conclave.integrationtests.general.common.tasks.ExecuteSql
 import com.r3.conclave.integrationtests.general.common.tasks.SqlQuery
 import com.r3.conclave.integrationtests.general.commontest.TestUtils
@@ -8,7 +7,6 @@ import com.r3.conclave.integrationtests.general.commontest.TestUtils.graalvmOnly
 import com.r3.conclave.integrationtests.general.commontest.TestUtils.simulationOnlyTest
 import com.r3.conclave.integrationtests.general.tests.filesystem.FileSystemEnclaveTest
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 
@@ -25,7 +23,7 @@ class DatabaseEnclaveTest : FileSystemEnclaveTest("com.r3.conclave.integrationte
 
         //  For Gramine, we want this test to run only in SIMULATION mode
         // CON-1268: Gramine: cannot access database
-        if (TestUtils.RuntimeType.GRAMINE.name == TestUtils.runtimeType.name) {
+        if (TestUtils.runtimeType == TestUtils.RuntimeType.GRAMINE) {
             simulationOnlyTest()
         }
 

--- a/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/filesystem/db/DatabaseEnclaveTest.kt
+++ b/integration-tests/general/tests/src/test/kotlin/com/r3/conclave/integrationtests/general/tests/filesystem/db/DatabaseEnclaveTest.kt
@@ -1,10 +1,13 @@
 package com.r3.conclave.integrationtests.general.tests.filesystem.db
 
+import com.r3.conclave.common.EnclaveMode
 import com.r3.conclave.integrationtests.general.common.tasks.ExecuteSql
 import com.r3.conclave.integrationtests.general.common.tasks.SqlQuery
+import com.r3.conclave.integrationtests.general.commontest.TestUtils
 import com.r3.conclave.integrationtests.general.commontest.TestUtils.graalvmOnlyTest
 import com.r3.conclave.integrationtests.general.tests.filesystem.FileSystemEnclaveTest
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 
@@ -17,7 +20,14 @@ class DatabaseEnclaveTest : FileSystemEnclaveTest("com.r3.conclave.integrationte
         "true, true"
     )
     fun `sql inside enclave`(restartBetweenCmds: Boolean, useKds: Boolean) {
-        if (restartBetweenCmds) graalvmOnlyTest() // CON-1268: Gramine: cannot access database after restarting the enclave
+        if (restartBetweenCmds) graalvmOnlyTest() // CON-1268: Gramine: cannot access database
+
+        //  For Gramine, we want this test to run only in SIMULATION mode
+        // CON-1268: Gramine: cannot access database
+        if (TestUtils.RuntimeType.GRAMINE.name == System.getProperty("runtimeType").uppercase()) {
+            assumeTrue(EnclaveMode.SIMULATION.name == System.getProperty("enclaveMode").uppercase())
+        }
+
         this.useKds = useKds
 
         callEnclave(ExecuteSql("""

--- a/integration-tests/pytorch-enclave/host/src/test/kotlin/com/r3/conclave/integrationtests/python/enclave/PytorchEnclaveTest.kt
+++ b/integration-tests/pytorch-enclave/host/src/test/kotlin/com/r3/conclave/integrationtests/python/enclave/PytorchEnclaveTest.kt
@@ -9,6 +9,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import java.io.ByteArrayOutputStream
 import java.io.DataOutputStream
@@ -16,6 +17,7 @@ import java.nio.file.Paths
 import kotlin.io.path.fileSize
 import kotlin.io.path.readBytes
 
+@Disabled // CON-1272: Pytorch integration test is failing with ModuleNotFoundError
 class PytorchEnclaveTest {
     companion object {
         @JvmStatic

--- a/integration-tests/tribuo/client/src/test/kotlin/com/r3/conclave/integrationtests/tribuo/client/AnomalyDetectionTest.kt
+++ b/integration-tests/tribuo/client/src/test/kotlin/com/r3/conclave/integrationtests/tribuo/client/AnomalyDetectionTest.kt
@@ -1,5 +1,7 @@
 package com.r3.conclave.integrationtests.tribuo.client
 
+import com.r3.conclave.integrationtests.general.commontest.TestUtils
+import com.r3.conclave.integrationtests.general.commontest.TestUtils.simulationOnlyTest
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.data.Offset
 import org.junit.jupiter.api.*
@@ -33,6 +35,10 @@ class AnomalyDetectionTest : TribuoTest() {
     @Order(1)
     @Test
     fun confusionMatrix() {
+        // Test fails for Gramine in debug mode. CON-1280: Tribuo AnomalyDetectionTest fails for Gramine in debug mode
+        if (TestUtils.runtimeType == TestUtils.RuntimeType.GRAMINE) {
+            simulationOnlyTest()
+        }
         val confusionMatrix = anomalyDetection.confusionMatrix().trim()
         assertThat(confusionMatrix).isEqualTo("""
             EXPECTED  ANOMALOUS

--- a/integration-tests/tribuo/client/src/test/kotlin/com/r3/conclave/integrationtests/tribuo/client/AnomalyDetectionTest.kt
+++ b/integration-tests/tribuo/client/src/test/kotlin/com/r3/conclave/integrationtests/tribuo/client/AnomalyDetectionTest.kt
@@ -35,7 +35,7 @@ class AnomalyDetectionTest : TribuoTest() {
     @Order(1)
     @Test
     fun confusionMatrix() {
-        // Test fails for Gramine in debug mode. CON-1280: Multiple Tribuo tests fail for Gramine in debug mode
+        // CON-1280: Multiple Tribuo tests fail for Gramine in debug mode
         if (TestUtils.runtimeType == TestUtils.RuntimeType.GRAMINE) {
             simulationOnlyTest()
         }

--- a/integration-tests/tribuo/client/src/test/kotlin/com/r3/conclave/integrationtests/tribuo/client/AnomalyDetectionTest.kt
+++ b/integration-tests/tribuo/client/src/test/kotlin/com/r3/conclave/integrationtests/tribuo/client/AnomalyDetectionTest.kt
@@ -35,7 +35,7 @@ class AnomalyDetectionTest : TribuoTest() {
     @Order(1)
     @Test
     fun confusionMatrix() {
-        // Test fails for Gramine in debug mode. CON-1280: Tribuo AnomalyDetectionTest fails for Gramine in debug mode
+        // Test fails for Gramine in debug mode. CON-1280: Multiple Tribuo tests fail for Gramine in debug mode
         if (TestUtils.runtimeType == TestUtils.RuntimeType.GRAMINE) {
             simulationOnlyTest()
         }

--- a/integration-tests/tribuo/client/src/test/kotlin/com/r3/conclave/integrationtests/tribuo/client/ClassificationTest.kt
+++ b/integration-tests/tribuo/client/src/test/kotlin/com/r3/conclave/integrationtests/tribuo/client/ClassificationTest.kt
@@ -29,7 +29,7 @@ class ClassificationTest : TribuoTest() {
         @BeforeAll
         @JvmStatic
         fun classificationSetup() {
-            // Test fails for Gramine in debug mode. CON-1280: Tribuo AnomalyDetectionTest fails for Gramine in debug mode
+            // Test fails for Gramine in debug mode. CON-1280: Multiple Tribuo tests fail for Gramine in debug mode
             if (TestUtils.runtimeType == TestUtils.RuntimeType.GRAMINE) {
                 TestUtils.simulationOnlyTest()
             }

--- a/integration-tests/tribuo/client/src/test/kotlin/com/r3/conclave/integrationtests/tribuo/client/ClassificationTest.kt
+++ b/integration-tests/tribuo/client/src/test/kotlin/com/r3/conclave/integrationtests/tribuo/client/ClassificationTest.kt
@@ -29,7 +29,7 @@ class ClassificationTest : TribuoTest() {
         @BeforeAll
         @JvmStatic
         fun classificationSetup() {
-            // Test fails for Gramine in debug mode. CON-1280: Multiple Tribuo tests fail for Gramine in debug mode
+            // CON-1280: Multiple Tribuo tests fail for Gramine in debug mode
             if (TestUtils.runtimeType == TestUtils.RuntimeType.GRAMINE) {
                 TestUtils.simulationOnlyTest()
             }

--- a/integration-tests/tribuo/client/src/test/kotlin/com/r3/conclave/integrationtests/tribuo/client/ClassificationTest.kt
+++ b/integration-tests/tribuo/client/src/test/kotlin/com/r3/conclave/integrationtests/tribuo/client/ClassificationTest.kt
@@ -1,5 +1,6 @@
 package com.r3.conclave.integrationtests.tribuo.client
 
+import com.r3.conclave.integrationtests.general.commontest.TestUtils
 import com.r3.conclave.integrationtests.tribuo.common.ClassEvaluationResult
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
@@ -28,6 +29,11 @@ class ClassificationTest : TribuoTest() {
         @BeforeAll
         @JvmStatic
         fun classificationSetup() {
+            // Test fails for Gramine in debug mode. CON-1280: Tribuo AnomalyDetectionTest fails for Gramine in debug mode
+            if (TestUtils.runtimeType == TestUtils.RuntimeType.GRAMINE) {
+                TestUtils.simulationOnlyTest()
+            }
+
             classification = Classification(client)
             enclaveIrisDataPath = classification.irisDataPath
         }
@@ -35,7 +41,7 @@ class ClassificationTest : TribuoTest() {
         @AfterAll
         @JvmStatic
         fun classificationTeardown() {
-            classification.close()
+            if (::classification.isInitialized) classification.close()
         }
     }
 

--- a/integration-tests/tribuo/client/src/test/kotlin/com/r3/conclave/integrationtests/tribuo/client/RegressionTest.kt
+++ b/integration-tests/tribuo/client/src/test/kotlin/com/r3/conclave/integrationtests/tribuo/client/RegressionTest.kt
@@ -1,5 +1,7 @@
 package com.r3.conclave.integrationtests.tribuo.client
 
+import com.r3.conclave.integrationtests.general.commontest.TestUtils
+import com.r3.conclave.integrationtests.general.commontest.TestUtils.simulationOnlyTest
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.data.Offset
 import org.junit.jupiter.api.*
@@ -25,13 +27,17 @@ class RegressionTest : TribuoTest() {
         @BeforeAll
         @JvmStatic
         fun regressionSetup() {
+            // Test fails for Gramine in debug mode. CON-1280: Tribuo AnomalyDetectionTest fails for Gramine in debug mode
+            if (TestUtils.runtimeType == TestUtils.RuntimeType.GRAMINE) {
+                simulationOnlyTest()
+            }
             regression = Regression(client)
         }
 
         @AfterAll
         @JvmStatic
         fun regressionTearDown() {
-            regression.close()
+            if (::regression.isInitialized) regression.close()
         }
     }
 

--- a/integration-tests/tribuo/client/src/test/kotlin/com/r3/conclave/integrationtests/tribuo/client/RegressionTest.kt
+++ b/integration-tests/tribuo/client/src/test/kotlin/com/r3/conclave/integrationtests/tribuo/client/RegressionTest.kt
@@ -27,7 +27,7 @@ class RegressionTest : TribuoTest() {
         @BeforeAll
         @JvmStatic
         fun regressionSetup() {
-            // Test fails for Gramine in debug mode. CON-1280: Tribuo AnomalyDetectionTest fails for Gramine in debug mode
+            // Test fails for Gramine in debug mode. CON-1280: Multiple Tribuo tests fail for Gramine in debug mode
             if (TestUtils.runtimeType == TestUtils.RuntimeType.GRAMINE) {
                 simulationOnlyTest()
             }

--- a/integration-tests/tribuo/client/src/test/kotlin/com/r3/conclave/integrationtests/tribuo/client/RegressionTest.kt
+++ b/integration-tests/tribuo/client/src/test/kotlin/com/r3/conclave/integrationtests/tribuo/client/RegressionTest.kt
@@ -27,7 +27,7 @@ class RegressionTest : TribuoTest() {
         @BeforeAll
         @JvmStatic
         fun regressionSetup() {
-            // Test fails for Gramine in debug mode. CON-1280: Multiple Tribuo tests fail for Gramine in debug mode
+            // CON-1280: Multiple Tribuo tests fail for Gramine in debug mode
             if (TestUtils.runtimeType == TestUtils.RuntimeType.GRAMINE) {
                 simulationOnlyTest()
             }

--- a/integration-tests/tribuo/client/src/test/kotlin/com/r3/conclave/integrationtests/tribuo/client/TribuoTest.kt
+++ b/integration-tests/tribuo/client/src/test/kotlin/com/r3/conclave/integrationtests/tribuo/client/TribuoTest.kt
@@ -32,7 +32,7 @@ open class TribuoTest {
         @BeforeAll
         @JvmStatic
         fun start() {
-            // Test fails for Gramine in debug mode. CON-1280: Multiple Tribuo tests fail for Gramine in debug mode
+            // CON-1280: Multiple Tribuo tests fail for Gramine in debug mode
             if (TestUtils.runtimeType == TestUtils.RuntimeType.GRAMINE) {
                 simulationOnlyTest()
             }

--- a/integration-tests/tribuo/client/src/test/kotlin/com/r3/conclave/integrationtests/tribuo/client/TribuoTest.kt
+++ b/integration-tests/tribuo/client/src/test/kotlin/com/r3/conclave/integrationtests/tribuo/client/TribuoTest.kt
@@ -32,7 +32,7 @@ open class TribuoTest {
         @BeforeAll
         @JvmStatic
         fun start() {
-            // Test fails for Gramine in debug mode. CON-1280: Tribuo AnomalyDetectionTest fails for Gramine in debug mode
+            // Test fails for Gramine in debug mode. CON-1280: Multiple Tribuo tests fail for Gramine in debug mode
             if (TestUtils.runtimeType == TestUtils.RuntimeType.GRAMINE) {
                 simulationOnlyTest()
             }

--- a/integration-tests/tribuo/client/src/test/kotlin/com/r3/conclave/integrationtests/tribuo/client/TribuoTest.kt
+++ b/integration-tests/tribuo/client/src/test/kotlin/com/r3/conclave/integrationtests/tribuo/client/TribuoTest.kt
@@ -4,6 +4,7 @@ import com.r3.conclave.common.EnclaveInstanceInfo
 import com.r3.conclave.host.EnclaveHost
 import com.r3.conclave.host.MailCommand
 import com.r3.conclave.integrationtests.general.commontest.TestUtils
+import com.r3.conclave.integrationtests.general.commontest.TestUtils.simulationOnlyTest
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.io.TempDir
@@ -31,6 +32,10 @@ open class TribuoTest {
         @BeforeAll
         @JvmStatic
         fun start() {
+            // Test fails for Gramine in debug mode. CON-1280: Tribuo AnomalyDetectionTest fails for Gramine in debug mode
+            if (TestUtils.runtimeType == TestUtils.RuntimeType.GRAMINE) {
+                simulationOnlyTest()
+            }
             enclaveHost = EnclaveHost.load("com.r3.conclave.integrationtests.tribuo.enclave.TribuoEnclave")
             val port = 9999
             println("Listening on port $port.")


### PR DESCRIPTION
Disable failing Gramine tests. Most of them are related to filesystem being not supported. 
New tickets were created to specify the failures. These are linked in the tests.

This PR gives green build of Gramine integration tests in Simulation mode.
Debug mode still fails on a new error, see https://r3-cev.atlassian.net/browse/CON-1165