### PR TITLE
Print entered runtimeType instead of a static string

### DIFF
--- a/scripts/ci_integration_tests.sh
+++ b/scripts/ci_integration_tests.sh
@@ -15,7 +15,7 @@ runtimeType=${2,,}
 
 # Check the entered enclave mode and runtime type
 [[ "mock simulation debug release" =~ (^|[[:space:]])$enclaveMode($|[[:space:]]) ]] && echo $enclaveMode || ( echo "Wrong enclave mode entered: $enclaveMode."; exit 1 )
-[[ "graalvm gramine" =~ (^|[[:space:]])$runtimeType($|[[:space:]]) ]] && echo &runtimeType || ( echo "Wrong runtime type entered: $runtimeType."; exit 1 )
+[[ "graalvm gramine" =~ (^|[[:space:]])$runtimeType($|[[:space:]]) ]] && echo $runtimeType || ( echo "Wrong runtime type entered: $runtimeType."; exit 1 )
 
 if [ "$enclaveMode" != "simulation" ] && [ "$runtimeType" == "gramine" ]; then
     # Hardware tests for Gramine need the AESM service running.

--- a/scripts/ci_integration_tests.sh
+++ b/scripts/ci_integration_tests.sh
@@ -15,7 +15,7 @@ runtimeType=${2,,}
 
 # Check the entered enclave mode and runtime type
 [[ "mock simulation debug release" =~ (^|[[:space:]])$enclaveMode($|[[:space:]]) ]] && echo $enclaveMode || ( echo "Wrong enclave mode entered: $enclaveMode."; exit 1 )
-[[ "graalvm gramine" =~ (^|[[:space:]])$runtimeType($|[[:space:]]) ]] && echo runtimeType || ( echo "Wrong runtime type entered: $runtimeType."; exit 1 )
+[[ "graalvm gramine" =~ (^|[[:space:]])$runtimeType($|[[:space:]]) ]] && echo &runtimeType || ( echo "Wrong runtime type entered: $runtimeType."; exit 1 )
 
 if [ "$enclaveMode" != "simulation" ] && [ "$runtimeType" == "gramine" ]; then
     # Hardware tests for Gramine need the AESM service running.


### PR DESCRIPTION
There was a bug when checking for entered runtimeType. It would not print the entered type, but just print static string 'runtimeType'.