### PR TITLE
CON-1221 - Remove hardcoded enclave size for Gramine

### DIFF
--- a/docs/docs/enclave-configuration.md
+++ b/docs/docs/enclave-configuration.md
@@ -40,6 +40,7 @@ conclave {
     revocationLevel = 0                 // Mandatory
     maxHeapSize = "256m"
     maxStackSize = "2m"
+    enclaveSize = "4G"
     inMemoryFileSystemSize = "64m"
     persistentFileSystemSize = "0m"
     enablePersistentMap = false
@@ -188,6 +189,19 @@ thread that runs inside the enclave.
 
 !!! tip
     As with `maxHeapSize`, the size is specified in bytes but you can put a `k`, `m` or `g` after the value to
+    specify it in kilobytes, megabytes or gigabytes respectively.
+
+### enclaveSize
+_Default:_ `4G`
+
+This is an advanced setting that specifies the enclave size, and it is only relevant when the `runtime` setting
+is set to `gramine`. Keep in mind that the value must be a power of 2 (2, 4, 8, 16,...). Normally you would not need to
+specify the `enclaveSize` in your configuration since the default of 4G is sufficient for most applications. Only change
+this setting if you are seeing errors related to memory allocations when the enclave is starting up. You are advise to set the enclave size to 
+8G if you intend to run python code inside the enclave.
+
+!!! tip
+    As with `enclaveSize`, the size is specified in bytes, but you can put a `K`, `M` or `G` after the value to
     specify it in kilobytes, megabytes or gigabytes respectively.
 
 ### inMemoryFileSystemSize

--- a/docs/docs/release-notes.md
+++ b/docs/docs/release-notes.md
@@ -7,8 +7,12 @@
 2. EPID attestation protocol has been deprecated, and it will be removed in an upcoming release. You should use DCAP instead.
 3. For security reasons, the way [enclave constraints](api/-conclave%20-core/com.r3.conclave.common/-enclave-constraint/index.html)
    are evaluated has changed slightly. From now on, if a client sets the security level to `INSECURE`, it will not pass
-   for `STALE` or `SECURE` enclaves. This is to prevent the client from accidently communicating with a production
+   for `STALE` or `SECURE` enclaves. This is to prevent the client from accidentally communicating with a production
    enclave during development or testing.
+4. The configuration field `enclaveSize` can be used to set the enclave size when the runtime is set to `gramine`.  The 
+   value must be always a power of two (`2G`, `4G`, `8G`, `16G`,...) and by default it is set to `4G`.
+   Please be aware that the size of the enclave must be set to at least `8G` if you decide to run python code inside the enclave
+   otherwise the enclave might fail to run.
 
 ## 1.3.1
 

--- a/integration-tests/pytorch-enclave/enclave/build.gradle
+++ b/integration-tests/pytorch-enclave/enclave/build.gradle
@@ -5,7 +5,7 @@ plugins {
 conclave {
     productID = 100
     revocationLevel = 2
-
+    enclaveSize = "8G"
     release {
         signingType = dummyKey
     }

--- a/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/ConclaveExtension.kt
+++ b/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/ConclaveExtension.kt
@@ -18,6 +18,8 @@ open class ConclaveExtension @Inject constructor(objects: ObjectFactory) {
     @get:Input
     val maxStackSize: Property<String> = objects.property(String::class.java).convention("2m")
     @get:Input
+    val enclaveSize: Property<String> = objects.property(String::class.java).convention("4G")
+    @get:Input
     val enablePersistentMap: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
     @get:Input
     val maxPersistentMapSize: Property<String> = objects.property(String::class.java).convention("16m")

--- a/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/GradleEnclavePlugin.kt
+++ b/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/GradleEnclavePlugin.kt
@@ -178,6 +178,7 @@ class GradleEnclavePlugin @Inject constructor(private val layout: ProjectLayout)
             task.revocationLevel.set(conclaveExtension.revocationLevel)
             task.maxThreads.set(conclaveExtension.maxThreads)
             task.enclaveJar.set(enclaveFatJarTask.archiveFile)
+            task.enclaveSize.set(conclaveExtension.enclaveSize)
             if (pythonSourcePath != null) {
                 val pythonFiles = target.fileTree(pythonSourcePath).files
                 task.pythonFile.set(pythonFiles.first())

--- a/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/gramine/GenerateGramineBundle.kt
+++ b/plugin-enclave-gradle/src/main/kotlin/com/r3/conclave/plugin/enclave/gradle/gramine/GenerateGramineBundle.kt
@@ -52,6 +52,9 @@ open class GenerateGramineBundle @Inject constructor(
     @get:Input
     val maxThreads: Property<Int> = objects.property(Int::class.java)
 
+    @get:Input
+    val enclaveSize: Property<String> = objects.property(String::class.java)
+
     @get:InputFile
     val signingKey: RegularFileProperty = objects.fileProperty()
 
@@ -141,7 +144,7 @@ open class GenerateGramineBundle @Inject constructor(
             "-Denclave_mode=$enclaveMode",
             "-Denclave_worker_threads=10",
             "-Dgramine_max_threads=${maxThreads.get()}",
-            "-Denclave_size=${if (pythonFile.isPresent) PYTHON_ENCLAVE_SIZE else JAVA_ENCLAVE_SIZE}",
+            "-Denclave_size=${enclaveSize.get()}",
             manifestTemplate.absolutePathString(),
             GRAMINE_MANIFEST
         )


### PR DESCRIPTION
Added the configuration field `enclaveSize` to allow the end-user to specify the size of the enclave. By default the size is 4G.